### PR TITLE
docs: Relates to #29. Converting Tables from Markdown to HTML 

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "stylesheet": [
     "./style.css"
   ],
-  "css": "body { } .dh-logo-readme,.download-whitepaper { display: none; } .pdf-only { display: block; } .pretty-link-colored { font-weight: 400; color: #00aaff !important; }",
+  "css": "body { } .dh-logo-readme,.download-whitepaper { display: none; } .pdf-only { display: block; } .pretty-link-colored { font-weight: 400; color: #00aaff !important; } table,tr,th,td { border: 1px solid black; text-align: center; } td { padding: 0.5em; }",
   "body_class": "markdown-body",
   "highlight_style": "monokai",
   "marked_options": {

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -551,7 +551,48 @@ Only a limited amount of End Devices will be roaming initially, but scalability 
 
 The initial economic variables shown in the table below were decided upon through optioneering and may be configured:
 
-![](https://i.imgur.com/tK4d8Lr.png)
+<table>
+    <tr>
+        <td>Genesis Total Supply (Monetary Base)</td>
+        <td>100000000</td>
+    </tr>
+    <tr>
+        <td>Genesis DHX DAO Treasury Unlocked Reserves</td>
+        <td>30000000</td>
+    </tr>
+    <tr>
+        <td>Remaining Genesis Supply</td>
+        <td>70000000</td>
+    </tr>
+    <tr>
+        <td>Genesis Estimated Staking Participation Collator Pool Size</td>
+        <td>100</td>
+    </tr>
+    <tr>
+        <td>Exchange Rate (USD per DHX) Assumption</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>Block Production / Mining Time</td>
+        <td>9</td>
+    </tr>
+    <tr>
+        <td>Initial Block Reward</td>
+        <td>0.25</td>
+    </tr>
+    <tr>
+        <td>Block Reward Collator Fees (% of Annual Supply)</td>
+        <td>20%</td>
+    </tr>
+    <tr>
+        <td>Block Reward Treasury Fees (% of Annual Supply)</td>
+        <td>80%</td>
+    </tr>
+    <tr>
+        <td>Inflation Cycle Duration (Years)</td>
+        <td>4</td>
+    </tr>
+</table>
 
 Table 1: DataHighway Economic Variables
 
@@ -600,7 +641,104 @@ The issuance of the DHX token is through either:
 
 The initial token issuance halving inflation strategy cycle (halving of the block production reward) shall occur every four (4) years using the "Decreasing-Supply Algorithm".
 
-![](https://i.imgur.com/o6x9GdJ.png)
+<table class="block-authoring">
+    <tr>
+        <th>Year</th>
+        <th>Inflation Cycle</th>
+        <th>Inflation Factor</th>
+        <th>Block Reward</th>
+        <th>Remaining Total Supply (DHX)</th>
+        <th>% of Total Supply Issued</th>
+    </tr>
+    <tr>
+        <td>2020</td>
+        <td>1</td>
+        <td>1.00</td>
+        <td>0.25</td>
+        <td>69121600</td>
+        <td>1.25</td>
+    </tr>
+    <tr>
+        <td>2021</td>
+        <td>1</td>
+        <td>1.00</td>
+        <td>0.25</td>
+        <td>68245600</td>
+        <td>2.51</td>
+    </tr>
+    <tr>
+        <td>2022</td>
+        <td>1</td>
+        <td>1.00</td>
+        <td>0.25</td>
+        <td>67369600</td>
+        <td>3.76</td>
+    </tr>
+    <tr>
+        <td>2023</td>
+        <td>1</td>
+        <td>1.00</td>
+        <td>0.25</td>
+        <td>66493600</td>
+        <td>5.01</td>
+    </tr>
+    <tr>
+        <td>2024</td>
+        <td>2</td>
+        <td>0.96</td>
+        <td>0.24</td>
+        <td>65650336</td>
+        <td>6.21</td>
+    </tr>
+    <tr>
+        <td>2025</td>
+        <td>2</td>
+        <td>0.96</td>
+        <td>0.24</td>
+        <td>64809376</td>
+        <td>7.42</td>
+    </tr>
+    <tr>
+        <td>2026</td>
+        <td>2</td>
+        <td>0.96</td>
+        <td>0.24</td>
+        <td>63968416</td>
+        <td>8.62</td>
+    </tr>
+    <tr>
+        <td>2027</td>
+        <td>2</td>
+        <td>0.96</td>
+        <td>0.24</td>
+        <td>63127456</td>
+        <td>9.82</td>
+    </tr>
+    <tr>
+        <td>2028</td>
+        <td>3</td>
+        <td>0.92</td>
+        <td>0.23</td>
+        <td>62317923</td>
+        <td>10.97</td>
+    </tr>
+    <tr>
+        <td>2029</td>
+        <td>3</td>
+        <td>0.92</td>
+        <td>0.23</td>
+        <td>61510601</td>
+        <td>12.13</td>
+    </tr>
+    <tr>
+        <td>2030</td>
+        <td>3</td>
+        <td>0.92</td>
+        <td>0.23</td>
+        <td>60703279</td>
+        <td>13.28</td>
+    </tr>
+</table>
 
 Table 2: Token Issuance Halving
 
@@ -647,17 +785,308 @@ The forecast collator pool size staking at genesis is 100.
 
 The consensus node capacity shall be 1000 (same as ChainX).
 
-![](https://i.imgur.com/PcMsSOE.png)
+<!-- http://beautifytools.com/csv-to-html-converter.php -->
+<table>
+    <tr>
+        <th rowspan="2">Year</th>
+        <th colspan="2">Block Production / Mining Rate</th>
+        <th colspan="3">Block Reward Issuance Breakdown (in DHX)</th>
+    </tr>
+    <tr>
+        <th>Per Min.</th>
+        <th>Per Day</th>
+        <th>Block Reward Issuance Per Min. (DHX)</th>
+        <th>Block Reward Issuance Per Day (DHX)</th>
+        <th>Block Reward Issuance Per Year (DHX)</th>
+    </tr>
+    <tr>
+        <td>2020</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6667</td>
+        <td>2400</td>
+        <td>876000</td>
+    </tr>
+    <tr>
+        <td>2021</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6667</td>
+        <td>2400</td>
+        <td>876000</td>
+    </tr>
+    <tr>
+        <td>2022</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6667</td>
+        <td>2400</td>
+        <td>876000</td>
+    </tr>
+    <tr>
+        <td>2023</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6667</td>
+        <td>2400</td>
+        <td>876000</td>
+    </tr>
+    <tr>
+        <td>2024</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6000</td>
+        <td>2304</td>
+        <td>840960</td>
+    </tr>
+    <tr>
+        <td>2025</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6000</td>
+        <td>2304</td>
+        <td>840960</td>
+    </tr>
+    <tr>
+        <td>2026</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6000</td>
+        <td>2304</td>
+        <td>840960</td>
+    </tr>
+    <tr>
+        <td>2027</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6000</td>
+        <td>2304</td>
+        <td>840960</td>
+    </tr>
+    <tr>
+        <td>2028</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.5360</td>
+        <td>2212</td>
+        <td>807322</td>
+    </tr>
+    <tr>
+        <td>2029</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.5360</td>
+        <td>2212</td>
+        <td>807322</td>
+    </tr>
+    <tr>
+        <td>2030</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.5360</td>
+        <td>2212</td>
+        <td>807322</td>
+    </tr>
+</table>
+
 
 Table 3: Block Production Rate & Block Reward
 
 Note: Block reward treasury and collator fees have been calculated using the treasury and collator fee rates respectively.
 
-![](https://i.imgur.com/mKO72Jp.png)
+<table>
+    <tr>
+        <th rowspan="3">Year</th>
+        <th colspan="5">Collator Estimates</th>
+    </tr>
+    <tr>
+        <th>Revenue (DHX)</th>
+        <th>Max. Revenue (DHX)</th>
+        <th>Costs (DHX)</th>
+        <th>ROI (Profit Factor)</th>
+        <th>ROI (Profit Factor)</th>
+    </tr>
+    <tr>
+        <th>Per Collator Per Year (Excluding MSB & MLB)</th>
+        <th>Per Collator Per Year (Including Max. MSB of 60% & Max. MLB of 20%)</th>
+        <th>Per Collator Per Year (Excluding MSB & MLB)</th>
+        <th>Per Collator Per Year (Excluding MSB & MLB)</th>
+        <th>Per Collator Per Year (Including MSB & MLB)</th>
+    </tr>
+    <tr>
+        <td>2020</td>
+        <td>1756.8</td>
+        <td>2810.9</td>
+        <td>120.0</td>
+        <td>14.6</td>
+        <td>23.4</td>
+    </tr>
+    <tr>
+        <td>2021</td>
+        <td>1752.0</td>
+        <td>2803.2</td>
+        <td>121.8</td>
+        <td>14.4</td>
+        <td>23.0</td>
+    </tr>
+    <tr>
+        <td>2022</td>
+        <td>1752.0</td>
+        <td>2803.2</td>
+        <td>123.6</td>
+        <td>14.2</td>
+        <td>22.7</td>
+    </tr>
+    <tr>
+        <td>2023</td>
+        <td>1752.0</td>
+        <td>2803.2</td>
+        <td>125.5</td>
+        <td>14.0</td>
+        <td>22.3</td>
+    </tr>
+    <tr>
+        <td>2024</td>
+        <td>1686.5</td>
+        <td>2698.4</td>
+        <td>127.4</td>
+        <td>13.2</td>
+        <td>21.2</td>
+    </tr>
+    <tr>
+        <td>2025</td>
+        <td>1681.9</td>
+        <td>2691.1</td>
+        <td>129.3</td>
+        <td>13.0</td>
+        <td>20.8</td>
+    </tr>
+    <tr>
+        <td>2026</td>
+        <td>1681.9</td>
+        <td>2691.1</td>
+        <td>131.2</td>
+        <td>12.8</td>
+        <td>20.5</td>
+    </tr>
+    <tr>
+        <td>2027</td>
+        <td>1681.9</td>
+        <td>2691.1</td>
+        <td>133.2</td>
+        <td>12.6</td>
+        <td>20.2</td>
+    </tr>
+    <tr>
+        <td>2028</td>
+        <td>1619.1</td>
+        <td>2590.5</td>
+        <td>135.2</td>
+        <td>12.0</td>
+        <td>19.2</td>
+    </tr>
+    <tr>
+        <td>2029</td>
+        <td>1614.6</td>
+        <td>2583.4</td>
+        <td>137.2</td>
+        <td>11.8</td>
+        <td>18.8</td>
+    </tr>
+    <tr>
+        <td>2030</td>
+        <td>1614.6</td>
+        <td>2583.4</td>
+        <td>139.3</td>
+        <td>11.6</td>
+        <td>18.6</td>
+    </tr>
+</table>
 
 Table 4: Collator Estimated ROI
 
-![](https://i.imgur.com/VtmfAjs.png)
+<table>
+    <tr>
+        <th rowspan="3">Year</th>
+        <th colspan="3">Block Reward Distribution</th>
+    </tr>
+    <tr>
+        <th>Issuance</th>
+        <th>Collator Fees</th>
+        <th>Treasury Fees</th>
+    </tr>
+    <tr>
+        <th>Per Year (DHX)</th>
+        <th>Per Year (DHX)</th>
+        <th>Per Year (DHX)</th>
+    </tr>
+    <tr>
+        <td>2020</td>
+        <td>878400</td>
+        <td>175680</td>
+        <td>702720</td>
+    </tr>
+    <tr>
+        <td>2021</td>
+        <td>876000</td>
+        <td>175200</td>
+        <td>700800</td>
+    </tr>
+    <tr>
+        <td>2022</td>
+        <td>876000</td>
+        <td>175200</td>
+        <td>700800</td>
+    </tr>
+    <tr>
+        <td>2023</td>
+        <td>876000</td>
+        <td>175200</td>
+        <td>700800</td>
+    </tr>
+    <tr>
+        <td>2024</td>
+        <td>843264</td>
+        <td>168653</td>
+        <td>674611</td>
+    </tr>
+    <tr>
+        <td>2025</td>
+        <td>840960</td>
+        <td>168192</td>
+        <td>672768</td>
+    </tr>
+    <tr>
+        <td>2026</td>
+        <td>840960</td>
+        <td>168192</td>
+        <td>672768</td>
+    </tr>
+    <tr>
+        <td>2027</td>
+        <td>840960</td>
+        <td>168192</td>
+        <td>672768</td>
+    </tr>
+    <tr>
+        <td>2028</td>
+        <td>809533</td>
+        <td>161907</td>
+        <td>647627</td>
+    </tr>
+    <tr>
+        <td>2029</td>
+        <td>807322</td>
+        <td>161464</td>
+        <td>645857</td>
+    </tr>
+    <tr>
+        <td>2030</td>
+        <td>807322</td>
+        <td>161464</td>
+        <td>645857</td>
+    </tr>
+</table>
 
 Table 5: Block Reward Distribution
 
@@ -845,6 +1274,197 @@ The DH's Cash Flow Statement reports for a period of time how changes in the Fin
 ![](https://i.imgur.com/Xom2VPv.png)
 
 ![](https://i.imgur.com/Hn8hTb9.png)
+
+<!-- HTML version below looks horrible -->
+
+<!-- <table style="font-size: 0.7em">
+    <tr>
+        <th>Activity Type</th>
+        <th>Name</th>
+        <th class="table-vertical-column-text">Revenue</th>
+        <th class="table-vertical-column-text">Expense</th>
+        <th>Payer</th>
+        <th>Payee</th>
+        <th>Sub-Type</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Anti-Tax Evasion Transaction Fee</td>
+        <td>X</td>
+        <td></td>
+        <td>Validator</td>
+        <td>DAO Treasury</td>
+        <td>Fee (Transaction)</td>
+        <td>Fee that must be paid (using a proportion of the block reward) by the validator that produced the block to pay for securing the blockchain to discourage validators from evading fees. Minimum fee to be paid by the Validator that shall apply per transaction is 20% of the block reward. This does not apply to Treasury validators. An additional per-byte fee may also be applied depending on the size of each transaction subject to DHX DAO approval. See [5] [6].</td>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Anti-DDoS Transaction Fee</td>
+        <td>X</td>
+        <td></td>
+        <td>End Users</td>
+        <td>Validator and DHX DAO Treasury</td>
+        <td>Fee (Transaction)</td>
+        <td>Fee that must be paid by the sender of a transaction to pay for securing the blockchain to reduce the likelihood of DDoS attacks. <br /><br />Free Transactions may apply subject to DHX DAO approval to user account proposals that demonstrated a history of staking PoP and an adequate DHX DAO Reputation Level</td>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Misbehaviour Penalty Fee</td>
+        <td>X</td>
+        <td></td>
+        <td>Validator</td>
+        <td>DHX DAO Treasury</td>
+        <td>Fee (Penalty)</td>
+        <td>Fee that must be paid by End Users as a penalty (slashing) for misbehaviour. It pays for maintaining the security of the blockchain</td>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Misbehaviour Penalty Fee</td>
+        <td>X</td>
+        <td></td>
+        <td>Validator (owned by DHX DAO Treasury)</td>
+        <td>N/A (Burn Tokens)</td>
+        <td>Negative Inflation</td>
+        <td>Fee that must be paid as a penalty (slashing) by the DHX DAO Treasury when they own a validator and are found to have misbehaved. It pays for maintaining the security of the blockchain.</td>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Halving</td>
+        <td>X</td>
+        <td></td>
+        <td>Monetary Reserve</td>
+        <td>Monetary Reserve</td>
+        <td>Negative Inflation</td>
+        <td>Initiate a negative inflation from genesis by adopting halving ("Decreasing-Supply Algorithm") to decrease the block reward every "Halving Period". The DHX DAO Treasury community may propose to change inflation to a different strategy such as no inflation ("Transaction-Fee-Only Model").</td>
+    </tr>
+    <tr>
+        <td>Investing</td>
+        <td>Sale of DHX tokens</td>
+        <td>X</td>
+        <td></td>
+        <td>End Users</td>
+        <td>DEX</td>
+        <td>Issuance (of Token by DEX) or Exchange (by End User)</td>
+        <td>DEX excluded for simpler design</td>
+    </tr>
+    <tr>
+        <td>Investing</td>
+        <td>Purchase of DHX tokens</td>
+        <td></td>
+        <td>X</td>
+        <td>DEX</td>
+        <td>End Users</td>
+        <td>Investment (by DEX) or Exchange (by End User)</td>
+        <td>DEX excluded for simpler design</td>
+    </tr>
+    <tr>
+        <td>Investing</td>
+        <td>Purchase of MXC, IOTA, or DOT for the DHX DAO Treasury's Unlocked Reserves</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>End Users</td>
+        <td>Investment</td>
+        <td>Tokens may be purchased for Quantitative Easing purposes.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Payment of Block Reward</td>
+        <td></td>
+        <td>X</td>
+        <td>Monetary Reserve</td>
+        <td>Validator</td>
+        <td>Issuance (Token)</td>
+        <td>Tokens issued by the Monetary Reserve to validators that produce a valid block (with a proportion of this block reward used for the anti-tax evasion fee or the whole block reward if the validator is owned by the DHX DAO Treasury). The goal is to incentivise economic participation in the blockchain's consensus protocol and secure the blockchain. Since the reward goes to the validator that mined the block that validator has an incentive equal to the value of the fees to include as many transactions as possible in the block whereas if the reward were shared equally with the validators then there would be negligible incentive [5]. DHX DAO community governance participants may elect to modify the level of security of the blockchain protocol (i.e. modify the total supply cap).</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Refund of Anti-Tax Evasion Transaction Fees</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>Validators</td>
+        <td>Refund</td>
+        <td>Refunds may apply subject to DHX DAO approval to user account proposals that demonstrated a healthy history of staking as a validator PoP and an adequate DHX DAO Reputation Level</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Rebate of Anti-DDoS Transaction Fees</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>End User</td>
+        <td>Rebate</td>
+        <td>Future bundled Rebate Requests may be proposed for DHX DAO approval based on their DHX DAO Reputation Level.</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>DHX DAO Treasury Unlocked Reserves to fund DHX DAO approved PoP MSBs (hashrate) through proposal evidence of Inter-Chain Bridged Asset Mining (ICBAM) and Hardware, Development, Advocacy and Governance Mining</td>
+        <td></td>
+        <td>X</td>
+        <td>Monetary Reserve</td>
+        <td>DHX DAO Treasury (then End User or DHX DAO Treasury)</td>
+        <td>Fund</td>
+        <td>DHX DAO unlocked reserve funds are reserved for potential future payment. A portion of them are allocated (within a daily limit) upon each DHX DAO approval of a proposal that contains evidence (PoP) of their entitlement eligibility to receive a MSB or MLB in DHX on top of any block reward that they may have earnt (up to an upper limit of 80% comprising 20% ICBAM MSB 40% non-ICBAM and 20% MLB) when validating or nominating over a period of time. <br /><br />To become entitled in addition to their stake having to have won the block reward the identity must first have participated prior through PoP means that the DHX DAO community would deem worthy to approve of.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Proposal requesting to allocate DHX DAO unlocked reserve entitlements for PoP</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>End Users or DHX DAO Treasury</td>
+        <td>Unlock (Tokens)</td>
+        <td>Release various DHX DAO unlocked reserve entitlements subject to DHX DAO Treasury community approval.  <br /><br />DHX DAO Treasury reviews proposals that are prioritised using a DHX DAO Proposal Prioritisation Formula that shall take into consideration weightings such as the DHX DAO Reputation of the proposer. <br /><br />Rejected proposals may be appealed through the DHX DAO Appeals Court. Rejected requests that are not appealed or are rejected by the appeal will have their entitlements allocated but shall remain in the DHX DAO Treasury.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Distribution of DHX DAO Treasury Unlocked Reserves</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>Various</td>
+        <td>Fund</td>
+        <td>DHX DAO Treasury Approvers that are eligible to approve proposals are selected using a formula that considers the proposers DHX DAO Reputation. DHX DAO Treasury Approvers are changed after each proposal. DHX DAO Treasury Approvers are responsible for rejecting or approving proposals (i.e. grant or loan request) that upon approval are allocated and distributed to the requestor. The proposal's requested funding amount determines DHX DAO Reputation Level that is required to be selected as a DHX DAO Treasury Approver (i.e. higher funding requested = higher reputation level to approve).
+        <br /><br />DHX DAO Treasury Grant Funding Proposals Reviewed Default Daily Limit applies to provide a daily upper limit on the quantity of proposals the DHX DAO may approve.
+        <br /><br />DHX DAO Treasury Grant Funding Amount Default Approval Limit applies to each requestor. Requestors may only increase it to a Custom amount through a DHX DAO decision that will take into consideration the requestor's DHX DAO Reputation (including their handing of funds that were distributed to them prior).
+        <br /><br />DHX DAO Treasury Grant Funding Staged Release Default Approval Times shall specify times when different proportions of the approved funds may be allocated for access by the requestor and with a proportion still possibly subject to the requestor providing further evidence of entitlement. The requestor's proposal may request that the funds be provided sooner at Custom times instead of the Default times through a DHX DAO decision that will take into consideration their DHX DAO Reputation (including their handing of funds that were distributed to them prior). <br /><br />DHX DAO Treasury Challenge Bounties shall be be used to fund identities in the community that identify inappropriate use of granted funds (similar to Fisherman that identify bad behaviour in the Polkadot network).
+        <br />DHX DAO Reputation Level (voting power) of an identity is measured by a DHX DAO Reputation Formula that takes into consideration weightings that include the identity's Staking history (both DH native and PoP history including prior DHX DAO proposal performance). The DHX DAO Reputation Formula and weightings may be changed through a DHX DAO decision.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>DHX DAO Dispute Resolution (Governance)</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury or End Users</td>
+        <td>End Users or DHX DAO Treasury</td>
+        <td>Dispute Resolution</td>
+        <td>DHX DAO Appeals Court handles dispute resolution. Disputes must be raised within a reasonable period of time after the disputed transaction or after DHX DAO Treasury rejection of a proposal.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Loan interest collected by DAO lending from borrowers</td>
+        <td>X</td>
+        <td></td>
+        <td>End Users</td>
+        <td>DEX</td>
+        <td>Fee (Interest)</td>
+        <td>DEX excluded for simpler design</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Loan from DAO lending to borrowing identities</td>
+        <td></td>
+        <td>X</td>
+        <td>DEX</td>
+        <td>End Users</td>
+        <td>Loan</td>
+        <td>DEX excluded for simpler design</td>
+    </tr>
+</table> -->
 
 Table 6: DH Cash Flow Statement
 

--- a/v1/whitepaper.html
+++ b/v1/whitepaper.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html><head>
 	<meta charset="utf-8">
-<style type="text/css">body { } .dh-logo-readme,.download-whitepaper { display: none; } .pdf-only { display: block; } .pretty-link-colored { font-weight: 400; color: #00aaff !important; }</style><style type="text/css">/*
+<style type="text/css">body { } .dh-logo-readme,.download-whitepaper { display: none; } .pdf-only { display: block; } .pretty-link-colored { font-weight: 400; color: #00aaff !important; } table,tr,th,td { border: 1px solid black; text-align: center; } td { padding: 0.5em; }</style><style type="text/css">/*
 Monokai style - ported by Luigi Maselli - http://grigio.org
 */
 
@@ -70,7 +70,7 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 .hljs-selector-id {
   font-weight: bold;
 }
-/*# sourceURL=/Users/ls/.nvm/versions/node/v12.16.0/lib/node_modules/md-to-pdf/node_modules/highlight.js/styles/monokai.css*/</style><style type="text/css">body {
+/*# sourceURL=/Users/ls/.nvm/versions/node/v12.7.0/lib/node_modules/md-to-pdf/node_modules/highlight.js/styles/monokai.css*/</style><style type="text/css">body {
   color: #000;
   font-size: 22px;
   font-family: Arial, Helvetica, sans-serif;
@@ -132,13 +132,13 @@ code {
 }
 /*# sourceURL=./style.css*/</style></head>
 <body class="markdown-body">
-<p><span style="font-size: 2em; font-weight: 700;!important" class="pdf-only">Data Highway’s Economic Whitepaper</span>
+<p><span style="font-size: 2em; font-weight: 700;!important" class="pdf-only">DataHighway’s Economic Whitepaper</span>
 <br></p>
 <div class="background-custom"></div>
 
 <div class="margin-sm"></div>
 
-<p><span class="language-options" style="font-style: italic;"><span class="download-whitepaper">Read this in other languages:</span> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.md" class="download-whitepaper pretty-link-colored">English</a> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.ko.md" class="download-whitepaper pretty-link-colored">한국어</a> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.ja.md" class="download-whitepaper pretty-link-colored">日本語</a> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.zh-cn.md" class="download-whitepaper pretty-link-colored">简体中文</a> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.zh-tw.md" class="download-whitepaper pretty-link-colored">正體中文</a></span></p>
+<p><span class="language-options" style="font-style: italic;"><span class="download-whitepaper">Read this in other languages:</span> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.md" class="download-whitepaper" style="font-weight: 400; color: #00aaff !important;">English</a> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.ko.md" class="download-whitepaper pretty-link-colored">한국어</a> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.ja.md" class="download-whitepaper pretty-link-colored">日本語</a> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.zh-cn.md" class="download-whitepaper pretty-link-colored">简体中文</a> <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/docs/whitepaper.zh-tw.md" class="download-whitepaper pretty-link-colored">正體中文</a></span></p>
 <!-- https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes -->
 <span>
     <a href="https://raw.githubusercontent.com/DataHighway-DHX/documentation/master/v1/whitepaper.pdf" class="download-whitepaper" style="margin: 40px; font-size:1.5em; font-weight: 700; color: #00aaff !important">DOWNLOAD WHITEPAPER</a>
@@ -147,353 +147,357 @@ code {
 <h2 id="contributions">Contributions</h2>
 <p>To contribute edits to this whitepaper, please submit pull requests to this repository with your changes.
 Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documentation/blob/master/CONTRIBUTING.md" target="_blank" class="pretty-link-colored">CONTRIBUTING</a> on how to Creating Issues and Pull Requests.</p>
-<h3 id="releases">Releases</h3>
-<p>Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documentation/blob/master/CONTRIBUTING.md" target="_blank" class="pretty-link-colored">CONTRIBUTING</a>.</p>
 <div class="margin-sm"></div>
 
 <h2 id="questions">Questions</h2>
 <p>If you have any questions, please join the <a href="https://discord.gg/KGTbv9Z" target="_blank" class="pretty-link-colored">DataHighway Discord</a> and ask in the #general channel.</p>
 <div class="page-break"></div>
 
-<h1 id="table-of-contents">Table of Contents</h1>
-<ul>
-<li><a href="#introduction">Introduction</a><ul>
-<li><a href="#dao">DAO</a></li>
-<li><a href="#mining">Mining</a></li>
-<li><a href="#inter-chain-data-market">Inter-Chain Data Market</a></li>
-<li><a href="#roaming">Roaming</a></li>
-</ul>
-</li>
-<li><a href="#goals">Goals</a><ul>
-<li><a href="#fair-distribution--decentralisation-model">Fair Distribution &amp; Decentralisation Model</a></li>
-<li><a href="#equal-participation-opportunity">Equal Participation Opportunity</a></li>
-<li><a href="#inter-chain-data-market-1">Inter-Chain Data Market</a></li>
-<li><a href="#roaming-1">Roaming</a><ul>
-<li><a href="#fully-decentralized-roaming-solution">Fully Decentralized Roaming Solution</a></li>
-<li><a href="#compatibility-with-the-lora-alliance">Compatibility with the LoRa Alliance</a></li>
-<li><a href="#integrates-with-other-roaming-hubs">Integrates with other Roaming Hubs</a></li>
-<li><a href="#automated-billing--charging">Automated Billing &amp; Charging</a></li>
-<li><a href="#competitive-low-cost-fair-access-and-consumer-protection">Competitive (Low-Cost), Fair Access, and Consumer Protection</a></li>
-<li><a href="#interfaces">Interfaces</a></li>
-<li><a href="#intuitive-ux">Intuitive UX</a></li>
-</ul>
-</li>
-<li><a href="#external-oracle">External Oracle</a></li>
-<li><a href="#scalability">Scalability</a></li>
-<li><a href="#security">Security</a></li>
-<li><a href="#auditable">Auditable</a></li>
-<li><a href="#plugins">Plugins</a></li>
-<li><a href="#dex">DEX</a></li>
-<li><a href="#api">API</a></li>
-</ul>
-</li>
-<li><a href="#roadmap">Roadmap</a><ul>
-<li><a href="#january-2020">January 2020</a></li>
-<li><a href="#february-2020">February 2020</a></li>
-<li><a href="#march-2020">March 2020</a></li>
-<li><a href="#april-2020">April 2020</a></li>
-<li><a href="#june-2020">June 2020</a></li>
-<li><a href="#july-2020">July 2020</a></li>
-</ul>
-</li>
-<li><a href="#economic-configuration">Economic Configuration</a><ul>
-<li><a href="#economic-variables">Economic Variables</a><ul>
-<li><a href="#genesis-total-symbol">Genesis Total Symbol</a></li>
-<li><a href="#genesis-total-supply">Genesis Total Supply</a></li>
-<li><a href="#block-production--mining-time">Block Production / Mining Time</a><ul>
-<li><a href="#comparison-with-other-networks">Comparison with Other Networks</a></li>
-</ul>
-</li>
-<li><a href="#exchange-rate">Exchange Rate</a></li>
-<li><a href="#future-changes">Future Changes</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#token-issuance">Token Issuance</a><ul>
-<li><a href="#token-issuance-options">Token Issuance Options</a><ul>
-<li><a href="#block-authoring--production-rewards">Block Authoring / Production Rewards</a><ul>
-<li><a href="#token-issuance-initial-rate">Token Issuance Initial Rate</a></li>
-<li><a href="#block-reward-issuance-rate">Block Reward Issuance Rate</a></li>
-<li><a href="#transactions-per-block">Transactions Per Block</a></li>
-<li><a href="#collators">Collators</a><ul>
-<li><a href="#collator-pool-size">Collator Pool Size</a></li>
-</ul>
-</li>
-<li><a href="#block-reward-treasury-fees">Block Reward Treasury Fees</a></li>
-</ul>
-</li>
-<li><a href="#allocating-dao-treasury-unlocked-reserves">Allocating DAO Treasury Unlocked Reserves</a></li>
-</ul>
-</li>
-<li><a href="#token-issuance-halving-inflation-strategy">Token Issuance Halving Inflation Strategy</a><ul>
-<li><a href="#about-halving">About Halving</a></li>
-<li><a href="#impact--benefits">Impact &amp; Benefits</a></li>
-<li><a href="#frequency">Frequency</a></li>
-<li><a href="#longevity">Longevity</a></li>
-<li><a href="#transparency">Transparency</a></li>
-<li><a href="#comparison-with-halving-on-the-bitcoin-network">Comparison with Halving on the Bitcoin Network</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#token-acquisition">Token Acquisition</a></li>
-<li><a href="#dao-1">DAO</a><ul>
-<li><a href="#treasury">Treasury</a><ul>
-<li><a href="#unlocked-reserves">Unlocked Reserves</a></li>
-</ul>
-</li>
-<li><a href="#future-monetary--fiscal-policies">Future Monetary &amp; Fiscal Policies</a></li>
-<li><a href="#financial-model">Financial Model</a><ul>
-<li><a href="#balance-sheet">Balance Sheet</a></li>
-<li><a href="#cash-flow-statement">Cash Flow Statement</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#mining-1">Mining</a><ul>
-<li><a href="#benefits">Benefits</a></li>
-<li><a href="#reward-options">Reward Options</a></li>
-<li><a href="#reward-types">Reward Types</a></li>
-<li><a href="#fixed-term-periods">Fixed Term Periods</a></li>
-<li><a href="#random-sampling-dates">Random Sampling Dates</a></li>
-<li><a href="#reward-spending--reinvestment">Reward Spending &amp; Reinvestment</a></li>
-<li><a href="#rules">Rules</a></li>
-<li><a href="#mining-speed-boost-msb">Mining Speed Boost (MSB)</a></li>
-<li><a href="#mining-loyalty-bonus-mlb">Mining Loyalty Bonus (MLB)</a></li>
-<li><a href="#mining-diversity-threshold-mdt">Mining Diversity Threshold (MDT)</a></li>
-<li><a href="#initial-asset-distribution">Initial Asset Distribution</a></li>
-<li><a href="#financial-model-1">Financial Model</a></li>
-<li><a href="#token-mining">Token Mining</a><ul>
-<li><a href="#goals-1">Goals</a></li>
-<li><a href="#background--benefits">Background &amp; Benefits</a></li>
-<li><a href="#rights">Rights</a><ul>
-<li><a href="#compounding-rewards">Compounding Rewards</a></li>
-</ul>
-</li>
-<li><a href="#costs">Costs</a></li>
-<li><a href="#registration">Registration</a></li>
-<li><a href="#reward-calculation">Reward Calculation</a></li>
-<li><a href="#example-pop-icbam-combo-mining-for-voting-power">Example: PoP ICBAM Combo Mining for Voting Power</a></li>
-<li><a href="#transfer-bridge">Transfer Bridge</a></li>
-<li><a href="#inter-chain-asset-mappings">Inter-Chain Asset Mappings</a></li>
-</ul>
-</li>
-<li><a href="#token-dex">Token DEX</a></li>
-<li><a href="#hardware-mining-hardware-as-collateral">Hardware Mining (Hardware as Collateral)</a><ul>
-<li><a href="#background--benefits-1">Background &amp; Benefits</a></li>
-<li><a href="#goals-2">Goals</a></li>
-<li><a href="#costs-1">Costs</a></li>
-<li><a href="#registration-1">Registration</a></li>
-<li><a href="#reward-calculation-1">Reward Calculation</a></li>
-<li><a href="#rights-1">Rights</a></li>
-<li><a href="#financial-model-2">Financial Model</a><ul>
-<li><a href="#example-pop-hardware-assets-combo-mining-for-voting-power">Example: PoP Hardware Assets Combo Mining for Voting Power</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#development-mining-runtimes--dapps-as-collateral">Development Mining (Runtimes &amp; DApps as Collateral)</a><ul>
-<li><a href="#background--benefits-2">Background &amp; Benefits</a></li>
-<li><a href="#goals-3">Goals</a></li>
-<li><a href="#costs-2">Costs</a></li>
-<li><a href="#tags">Tags</a></li>
-<li><a href="#registration-2">Registration</a></li>
-<li><a href="#reward-calculation-2">Reward Calculation</a></li>
-<li><a href="#rights-2">Rights</a></li>
-<li><a href="#financial-model-3">Financial Model</a></li>
-</ul>
-</li>
-<li><a href="#advocacy-mining-marketing-as-collateral">Advocacy Mining (Marketing as Collateral)</a><ul>
-<li><a href="#background--benefits-3">Background &amp; Benefits</a></li>
-<li><a href="#goals-4">Goals</a></li>
-<li><a href="#costs-3">Costs</a></li>
-<li><a href="#tags-1">Tags</a></li>
-<li><a href="#registration-3">Registration</a></li>
-<li><a href="#reward-calculation-3">Reward Calculation</a></li>
-<li><a href="#rights-3">Rights</a></li>
-<li><a href="#financial-model-4">Financial Model</a></li>
-</ul>
-</li>
-<li><a href="#governance-mining-governance-as-collateral">Governance Mining (Governance as Collateral)</a><ul>
-<li><a href="#background--benefits-4">Background &amp; Benefits</a></li>
-<li><a href="#goals-5">Goals</a></li>
-<li><a href="#costs-4">Costs</a></li>
-<li><a href="#registration-4">Registration</a></li>
-<li><a href="#reward-calculation-4">Reward Calculation</a></li>
-<li><a href="#rights-4">Rights</a></li>
-<li><a href="#financial-model-5">Financial Model</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#roaming-2">Roaming</a><ul>
-<li><a href="#economics">Economics</a><ul>
-<li><a href="#payment-and-monthly-audit-process">Payment and Monthly Audit Process</a></li>
-<li><a href="#transaction-fees-subscription-based-or-ad-hoc-usage">Transaction Fees (Subscription-based or Ad-Hoc Usage)</a></li>
-<li><a href="#operations-fees">Operations Fees</a><ul>
-<li><a href="#subscription">Subscription</a></li>
-<li><a href="#ad-hoc">Ad-Hoc</a></li>
-</ul>
-</li>
-<li><a href="#default-roaming-fees">Default Roaming Fees</a></li>
-<li><a href="#changes-to-roaming-fees">Changes to Roaming Fees</a></li>
-<li><a href="#risks--mitigation-measures">Risks &amp; Mitigation Measures</a></li>
-<li><a href="#token-acquisition-dhx">Token Acquisition (DHX)</a></li>
-</ul>
-</li>
-<li><a href="#data-storage">Data Storage</a><ul>
-<li><a href="#storage-requirements">Storage Requirements</a></li>
-<li><a href="#storage-periodic-maintenance-and-migration">Storage Periodic Maintenance and Migration</a><ul>
-<li><a href="#data-pruning">Data Pruning</a></li>
-<li><a href="#data-retention-and-periodic-migration">Data Retention and Periodic Migration</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#architecture">Architecture</a><ul>
-<li><a href="#class-diagrams">Class Diagrams</a><ul>
-<li><a href="#aggregations-of-smb-and-forwarding">Aggregations (of SMB and Forwarding)</a></li>
-</ul>
-</li>
-<li><a href="#class-diagram-simplified">Class Diagram (Simplified)</a></li>
-<li><a href="#swimlane-flowchart-diagrams">Swimlane (Flowchart) Diagrams</a><ul>
-<li><a href="#lpwan-supernode-network-setup-shared-identity--staking">LPWAN Supernode Network Setup, Shared Identity &amp; Staking</a></li>
-<li><a href="#gateway-setup--staking">Gateway Setup &amp; Staking</a></li>
-<li><a href="#end-device-setup--staking">End Device Setup &amp; Staking</a></li>
-<li><a href="#end-device-roaming-setup">End Device Roaming Setup</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#use-cases">Use Cases</a><ul>
-<li><a href="#roaming-with-mxc-end-device-between-supernodes-registered-on-mxc-network">Roaming with MXC End Device between Supernodes Registered on MXC Network</a></li>
-<li><a href="#roaming-at-a-supernode-that-is-registered-on-the-mxc-network-using-an-end-device-from-a-different-network-operator-that-is-registered-on-thingpark-exchange-tex">Roaming at a Supernode that is registered on the MXC Network using an End Device from a different Network Operator that is registered on ThingPark Exchange (TEX)</a></li>
-<li><a href="#flowchart-diagrams">Flowchart Diagrams</a></li>
-<li><a href="#roaming-at-a-swisscom-network-server-ns-using-an-end-device-from-a-different-network-operator-eg-mxc-swisscom-that-is-registered-on-thingpark-exchange-tex">Roaming at a Swisscom Network Server (NS) using an End Device from a different Network Operator (e.g. MXC, Swisscom) that is registered on ThingPark Exchange (TEX)</a></li>
-</ul>
-</li>
-<li><a href="#ux-design">UX Design</a><ul>
-<li><a href="#proposed-roaming-integration-into-mxprotocol-of-lpwan-supernodes">Proposed Roaming Integration into MXProtocol of LPWAN Supernodes</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#inter-chain-data-market-2">Inter-Chain Data Market</a><ul>
-<li><a href="#data-trading">Data Trading</a><ul>
-<li><a href="#ux-design-1">UX Design</a></li>
-<li><a href="#class-diagram">Class Diagram</a><ul>
-<li><a href="#data-item-end-device-data-listed-on-inter-chain-data-market--purchase-order-granting-access-with-data-validated--certified">Data Item (End Device Data) Listed on Inter-Chain Data Market &amp; Purchase Order Granting Access with Data Validated &amp; Certified</a></li>
-</ul>
-</li>
-<li><a href="#swimlane-flowchart-diagrams-1">Swimlane (Flowchart) Diagrams</a><ul>
-<li><a href="#data-seller-configures-end-device-sensor-data-frames-for-graphs-on-m2m-portal">Data Seller configures End Device (Sensor) Data Frames for Graphs on M2M Portal</a></li>
-<li><a href="#data-seller-configures-end-device-sensor-data-visualizations--monitoring-for-dashboard-on-inter-chain-data-market">Data Seller configures End Device (Sensor) Data Visualizations &amp; Monitoring for Dashboard on Inter-Chain Data Market</a></li>
-<li><a href="#data-seller-configures-sale--auction-of-end-device-sensor-data-listing-on-inter-chain-data-market">Data Seller configures Sale / Auction of End Device (Sensor) Data Listing on Inter-Chain Data Market</a><ul>
-<li><a href="#data-buyer-requirements">Data Buyer Requirements</a></li>
-<li><a href="#data-buyer-choices">Data Buyer Choices</a></li>
-</ul>
-</li>
-<li><a href="#data-buyer-purchases--bids-for-access-grant-to-end-device-sensor-data-listing-on-inter-chain-data-market">Data Buyer Purchases / Bids for Access Grant to End Device (Sensor) Data Listing on Inter-Chain Data Market</a><ul>
-<li><a href="#data-buyer-payment-options">Data Buyer Payment Options</a></li>
-</ul>
-</li>
-<li><a href="#data-buyer-accesses-sensor-data-frames-from-inter-chain-decentralized-app-dapp">Data Buyer Accesses Sensor Data Frames from Inter-Chain Decentralized App (DApp)</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#data-validation">Data Validation</a><ul>
-<li><a href="#external-oracles">External Oracles</a><ul>
-<li><a href="#purpose">Purpose</a></li>
-<li><a href="#definition">Definition</a></li>
-<li><a href="#types">Types</a></li>
-<li><a href="#risk-ratings">Risk Ratings</a></li>
-<li><a href="#example">Example</a></li>
-</ul>
-</li>
-<li><a href="#swimlane-flowchart-diagrams-2">Swimlane (Flowchart) Diagrams</a><ul>
-<li><a href="#validate--certify--store-external-data-frames-retrieved-using-oracles-notaries--data-storage-backend">Validate &amp; Certify &amp; Store External Data Frames Retrieved using Oracles, Notaries &amp; Data Storage Backend</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#data-monitoring">Data Monitoring</a><ul>
-<li><a href="#business-concept-diagram">Business Concept Diagram</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#application-ecosystem">Application Ecosystem</a></li>
-<li><a href="#technical-model">Technical Model</a><ul>
-<li><a href="#consensus">Consensus</a></li>
-<li><a href="#custom-substrate-runtime-modules">Custom Substrate Runtime Modules</a></li>
-<li><a href="#node">Node</a></li>
-<li><a href="#other-infrastructure">Other Infrastructure</a></li>
-</ul>
-</li>
-<li><a href="#glossary">Glossary</a><ul>
-<li><a href="#mining-2">Mining</a></li>
-<li><a href="#roaming-3">Roaming</a></li>
-</ul>
-</li>
-<li><a href="#abbreviations">Abbreviations</a><ul>
-<li><a href="#mining-3">Mining</a></li>
-<li><a href="#roaming-4">Roaming</a></li>
-</ul>
-</li>
-<li><a href="#references">References</a></li>
-<li><a href="#appendices">Appendices</a><ul>
-<li><a href="#appendix-1-general---technical-model-of-substrate">Appendix 1: General - Technical Model of Substrate</a><ul>
-<li><a href="#integration-of-the-data-highway-parachain-into-the-polkadot-network">Integration of the Data Highway Parachain into the Polkadot network</a></li>
-</ul>
-</li>
-<li><a href="#appendix-2-roaming---lorawan-technology">Appendix 2: Roaming - LoRaWAN Technology</a></li>
-<li><a href="#appendix-3-roaming---use-case-alice-and-bob">Appendix 3: Roaming - Use Case (Alice and Bob)</a><ul>
-<li><a href="#assumptions">Assumptions</a></li>
-<li><a href="#user-personas">User Personas</a></li>
-<li><a href="#user-story">User Story</a></li>
-</ul>
-</li>
-</ul>
-</li>
-</ul>
-<p>Note: Generate a new chapter with <code>openssl rand -hex 3</code></p>
-<p>Note: Update the TOC by installing <a href="https://github.com/jonschlinkert/markdown-toc">markdown-toc</a>, and then running <code>cd ./node_modules/markdown-toc/ &amp;&amp; node cli.js --bullets "*"  --no-firsth1 ../../README.md</code> and replacing the current TOC with the output.</p>
+<div class="pdf-only">
+    <span style="font-size: 1.5em; font-weight: 700;!important" class="pdf-only">Table of Contents</span>
+    <!-- INSERT TOC BELOW HERE -->
+    <ul>
+    <li><a href="#releases">Releases</a></li>
+    <li><a href="#questions">Questions</a></li>
+    <li><a href="#table-of-contents">Table of Contents</a></li>
+    <li><a href="#introduction">Introduction</a>
+    <ul>
+    <li><a href="#dao">DAO</a></li>
+    <li><a href="#mining">Mining</a></li>
+    <li><a href="#inter-chain-data-market">Inter-Chain Data Market</a></li>
+    <li><a href="#lpwan">LPWAN</a></li>
+    <li><a href="#roaming">Roaming</a></li>
+    </ul></li>
+    <li><a href="#goals">Goals</a>
+    <ul>
+    <li><a href="#fair-distribution--decentralisation-model">Fair Distribution &amp; Decentralisation Model</a></li>
+    <li><a href="#equal-participation-opportunity">Equal Participation Opportunity</a></li>
+    <li><a href="#inter-chain-data-market-1">Inter-Chain Data Market</a></li>
+    <li><a href="#roaming-1">Roaming</a>
+    <ul>
+    <li><a href="#fully-decentralized-roaming-solution">Fully Decentralized Roaming Solution</a></li>
+    <li><a href="#compatibility-with-the-lora-alliance">Compatibility with the LoRa Alliance</a></li>
+    <li><a href="#integrates-with-other-roaming-hubs">Integrates with other Roaming Hubs</a></li>
+    <li><a href="#automated-billing--charging">Automated Billing &amp; Charging</a></li>
+    <li><a href="#competitive-low-cost-fair-access-and-consumer-protection">Competitive (Low-Cost), Fair Access, and Consumer Protection</a></li>
+    <li><a href="#interfaces">Interfaces</a></li>
+    <li><a href="#intuitive-ux">Intuitive UX</a></li>
+    </ul></li>
+    <li><a href="#external-oracle">External Oracle</a></li>
+    <li><a href="#scalability">Scalability</a></li>
+    <li><a href="#security">Security</a></li>
+    <li><a href="#auditable">Auditable</a></li>
+    <li><a href="#plugins">Plugins</a></li>
+    <li><a href="#dex">DEX</a></li>
+    <li><a href="#api">API</a></li>
+    </ul></li>
+    <li><a href="#roadmap">Roadmap</a>
+    <ul>
+    <li><a href="#january-2020">January 2020</a></li>
+    <li><a href="#february-2020">February 2020</a></li>
+    <li><a href="#march-2020">March 2020</a></li>
+    <li><a href="#april-2020">April 2020</a></li>
+    <li><a href="#june-2020">June 2020</a></li>
+    <li><a href="#july-2020">July 2020</a></li>
+    </ul></li>
+    <li><a href="#economic-configuration">Economic Configuration</a>
+    <ul>
+    <li><a href="#economic-variables">Economic Variables</a>
+    <ul>
+    <li><a href="#genesis-total-symbol">Genesis Total Symbol</a></li>
+    <li><a href="#genesis-total-supply">Genesis Total Supply</a></li>
+    <li><a href="#block-production--mining-time">Block Production / Mining Time</a>
+    <ul>
+    <li><a href="#comparison-with-other-networks">Comparison with Other Networks</a></li>
+    </ul></li>
+    <li><a href="#exchange-rate">Exchange Rate</a></li>
+    <li><a href="#future-changes">Future Changes</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#token-issuance">Token Issuance</a>
+    <ul>
+    <li><a href="#token-issuance-options">Token Issuance Options</a>
+    <ul>
+    <li><a href="#block-authoring--production-rewards">Block Authoring / Production Rewards</a>
+    <ul>
+    <li><a href="#token-issuance-initial-rate">Token Issuance Initial Rate</a></li>
+    <li><a href="#block-reward-issuance-rate">Block Reward Issuance Rate</a></li>
+    <li><a href="#transactions-per-block">Transactions Per Block</a></li>
+    <li><a href="#collators">Collators</a>
+    <ul>
+    <li><a href="#collator-pool-size">Collator Pool Size</a></li>
+    </ul></li>
+    <li><a href="#block-reward-treasury-fees">Block Reward Treasury Fees</a></li>
+    </ul></li>
+    <li><a href="#allocating-dao-treasury-unlocked-reserves">Allocating DAO Treasury Unlocked Reserves</a></li>
+    </ul></li>
+    <li><a href="#token-issuance-halving-inflation-strategy">Token Issuance Halving Inflation Strategy</a>
+    <ul>
+    <li><a href="#about-halving">About Halving</a></li>
+    <li><a href="#impact--benefits">Impact &amp; Benefits</a></li>
+    <li><a href="#frequency">Frequency</a></li>
+    <li><a href="#longevity">Longevity</a></li>
+    <li><a href="#transparency">Transparency</a></li>
+    <li><a href="#comparison-with-halving-on-the-bitcoin-network">Comparison with Halving on the Bitcoin Network</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#token-acquisition">Token Acquisition</a></li>
+    <li><a href="#dao-1">DAO</a>
+    <ul>
+    <li><a href="#treasury">Treasury</a>
+    <ul>
+    <li><a href="#unlocked-reserves">Unlocked Reserves</a></li>
+    </ul></li>
+    <li><a href="#future-monetary--fiscal-policies">Future Monetary &amp; Fiscal Policies</a></li>
+    <li><a href="#financial-model">Financial Model</a>
+    <ul>
+    <li><a href="#balance-sheet">Balance Sheet</a></li>
+    <li><a href="#cash-flow-statement">Cash Flow Statement</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#mining-1">Mining</a>
+    <ul>
+    <li><a href="#benefits">Benefits</a></li>
+    <li><a href="#reward-options">Reward Options</a></li>
+    <li><a href="#reward-types">Reward Types</a></li>
+    <li><a href="#fixed-term-periods">Fixed Term Periods</a></li>
+    <li><a href="#random-sampling-dates">Random Sampling Dates</a></li>
+    <li><a href="#reward-spending--reinvestment">Reward Spending &amp; Reinvestment</a></li>
+    <li><a href="#rules">Rules</a></li>
+    <li><a href="#mining-speed-boost-msb">Mining Speed Boost (MSB)</a></li>
+    <li><a href="#mining-loyalty-bonus-mlb">Mining Loyalty Bonus (MLB)</a></li>
+    <li><a href="#mining-diversity-threshold-mdt">Mining Diversity Threshold (MDT)</a></li>
+    <li><a href="#initial-asset-distribution">Initial Asset Distribution</a></li>
+    <li><a href="#financial-model-1">Financial Model</a></li>
+    <li><a href="#token-mining">Token Mining</a>
+    <ul>
+    <li><a href="#goals-1">Goals</a></li>
+    <li><a href="#background--benefits">Background &amp; Benefits</a></li>
+    <li><a href="#rights">Rights</a>
+    <ul>
+    <li><a href="#compounding-rewards">Compounding Rewards</a></li>
+    </ul></li>
+    <li><a href="#costs">Costs</a></li>
+    <li><a href="#registration">Registration</a></li>
+    <li><a href="#reward-calculation">Reward Calculation</a></li>
+    <li><a href="#example-pop-icbam-combo-mining-for-voting-power">Example: PoP ICBAM Combo Mining for Voting Power</a></li>
+    <li><a href="#transfer-bridge">Transfer Bridge</a></li>
+    <li><a href="#inter-chain-asset-mappings">Inter-Chain Asset Mappings</a></li>
+    </ul></li>
+    <li><a href="#token-dex">Token DEX</a></li>
+    <li><a href="#hardware-mining-hardware-as-collateral">Hardware Mining (Hardware as Collateral)</a>
+    <ul>
+    <li><a href="#background--benefits-1">Background &amp; Benefits</a></li>
+    <li><a href="#goals-2">Goals</a></li>
+    <li><a href="#costs-1">Costs</a></li>
+    <li><a href="#registration-1">Registration</a></li>
+    <li><a href="#reward-calculation-1">Reward Calculation</a></li>
+    <li><a href="#rights-1">Rights</a></li>
+    <li><a href="#financial-model-2">Financial Model</a>
+    <ul>
+    <li><a href="#example-pop-hardware-assets-combo-mining-for-voting-power">Example: PoP Hardware Assets Combo Mining for Voting Power</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#development-mining-runtimes--dapps-as-collateral">Development Mining (Runtimes &amp; DApps as Collateral)</a>
+    <ul>
+    <li><a href="#background--benefits-2">Background &amp; Benefits</a></li>
+    <li><a href="#goals-3">Goals</a></li>
+    <li><a href="#costs-2">Costs</a></li>
+    <li><a href="#tags">Tags</a></li>
+    <li><a href="#registration-2">Registration</a></li>
+    <li><a href="#reward-calculation-2">Reward Calculation</a></li>
+    <li><a href="#rights-2">Rights</a></li>
+    <li><a href="#financial-model-3">Financial Model</a></li>
+    </ul></li>
+    <li><a href="#advocacy-mining-marketing-as-collateral">Advocacy Mining (Marketing as Collateral)</a>
+    <ul>
+    <li><a href="#background--benefits-3">Background &amp; Benefits</a></li>
+    <li><a href="#goals-4">Goals</a></li>
+    <li><a href="#costs-3">Costs</a></li>
+    <li><a href="#tags-1">Tags</a></li>
+    <li><a href="#registration-3">Registration</a></li>
+    <li><a href="#reward-calculation-3">Reward Calculation</a></li>
+    <li><a href="#rights-3">Rights</a></li>
+    <li><a href="#financial-model-4">Financial Model</a></li>
+    </ul></li>
+    <li><a href="#governance-mining-governance-as-collateral">Governance Mining (Governance as Collateral)</a>
+    <ul>
+    <li><a href="#background--benefits-4">Background &amp; Benefits</a></li>
+    <li><a href="#goals-5">Goals</a></li>
+    <li><a href="#costs-4">Costs</a></li>
+    <li><a href="#registration-4">Registration</a></li>
+    <li><a href="#reward-calculation-4">Reward Calculation</a></li>
+    <li><a href="#rights-4">Rights</a></li>
+    <li><a href="#financial-model-5">Financial Model</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#roaming-2">Roaming</a>
+    <ul>
+    <li><a href="#economics">Economics</a>
+    <ul>
+    <li><a href="#payment-and-monthly-audit-process">Payment and Monthly Audit Process</a></li>
+    <li><a href="#transaction-fees-subscription-based-or-ad-hoc-usage">Transaction Fees (Subscription-based or Ad-Hoc Usage)</a></li>
+    <li><a href="#operations-fees">Operations Fees</a>
+    <ul>
+    <li><a href="#subscription">Subscription</a></li>
+    <li><a href="#ad-hoc">Ad-Hoc</a></li>
+    </ul></li>
+    <li><a href="#default-roaming-fees">Default Roaming Fees</a></li>
+    <li><a href="#changes-to-roaming-fees">Changes to Roaming Fees</a></li>
+    <li><a href="#risks--mitigation-measures">Risks &amp; Mitigation Measures</a></li>
+    <li><a href="#token-acquisition-dhx">Token Acquisition (DHX)</a></li>
+    </ul></li>
+    <li><a href="#data-storage">Data Storage</a>
+    <ul>
+    <li><a href="#storage-requirements">Storage Requirements</a></li>
+    <li><a href="#storage-periodic-maintenance-and-migration">Storage Periodic Maintenance and Migration</a>
+    <ul>
+    <li><a href="#data-pruning">Data Pruning</a></li>
+    <li><a href="#data-retention-and-periodic-migration">Data Retention and Periodic Migration</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#architecture">Architecture</a>
+    <ul>
+    <li><a href="#class-diagrams">Class Diagrams</a>
+    <ul>
+    <li><a href="#aggregations-of-smb-and-forwarding">Aggregations (of SMB and Forwarding)</a></li>
+    </ul></li>
+    <li><a href="#class-diagram-simplified">Class Diagram (Simplified)</a></li>
+    <li><a href="#swimlane-flowchart-diagrams">Swimlane (Flowchart) Diagrams</a>
+    <ul>
+    <li><a href="#lpwan-supernode-network-setup-shared-identity--staking">LPWAN Supernode Network Setup, Shared Identity &amp; Staking</a></li>
+    <li><a href="#gateway-setup--staking">Gateway Setup &amp; Staking</a></li>
+    <li><a href="#end-device-setup--staking">End Device Setup &amp; Staking</a></li>
+    <li><a href="#end-device-roaming-setup">End Device Roaming Setup</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#use-cases">Use Cases</a>
+    <ul>
+    <li><a href="#roaming-with-mxc-end-device-between-supernodes-registered-on-mxc-network">Roaming with MXC End Device between Supernodes Registered on MXC Network</a></li>
+    <li><a href="#roaming-at-a-supernode-that-is-registered-on-the-mxc-network-using-an-end-device-from-a-different-network-operator-that-is-registered-on-thingpark-exchange-tex">Roaming at a Supernode that is registered on the MXC Network using an End Device from a different Network Operator that is registered on ThingPark Exchange (TEX)</a></li>
+    <li><a href="#flowchart-diagrams">Flowchart Diagrams</a></li>
+    <li><a href="#roaming-at-a-swisscom-network-server-ns-using-an-end-device-from-a-different-network-operator-eg-mxc-swisscom-that-is-registered-on-thingpark-exchange-tex">Roaming at a Swisscom Network Server (NS) using an End Device from a different Network Operator (e.g. MXC, Swisscom) that is registered on ThingPark Exchange (TEX)</a></li>
+    </ul></li>
+    <li><a href="#ux-design">UX Design</a>
+    <ul>
+    <li><a href="#proposed-roaming-integration-into-mxprotocol-of-lpwan-supernodes">Proposed Roaming Integration into MXProtocol of LPWAN Supernodes</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#inter-chain-data-market-2">Inter-Chain Data Market</a>
+    <ul>
+    <li><a href="#data-trading">Data Trading</a>
+    <ul>
+    <li><a href="#ux-design-1">UX Design</a></li>
+    <li><a href="#class-diagram">Class Diagram</a>
+    <ul>
+    <li><a href="#data-item-end-device-data-listed-on-inter-chain-data-market--purchase-order-granting-access-with-data-validated--certified">Data Item (End Device Data) Listed on Inter-Chain Data Market &amp; Purchase Order Granting Access with Data Validated &amp; Certified</a></li>
+    </ul></li>
+    <li><a href="#swimlane-flowchart-diagrams-1">Swimlane (Flowchart) Diagrams</a>
+    <ul>
+    <li><a href="#data-seller-configures-end-device-sensor-data-frames-for-graphs-on-m2m-portal">Data Seller configures End Device (Sensor) Data Frames for Graphs on M2M Portal</a></li>
+    <li><a href="#data-seller-configures-end-device-sensor-data-visualizations--monitoring-for-dashboard-on-inter-chain-data-market">Data Seller configures End Device (Sensor) Data Visualizations &amp; Monitoring for Dashboard on Inter-Chain Data Market</a></li>
+    <li><a href="#data-seller-configures-sale--auction-of-end-device-sensor-data-listing-on-inter-chain-data-market">Data Seller configures Sale / Auction of End Device (Sensor) Data Listing on Inter-Chain Data Market</a>
+    <ul>
+    <li><a href="#data-buyer-requirements">Data Buyer Requirements</a></li>
+    <li><a href="#data-buyer-choices">Data Buyer Choices</a></li>
+    </ul></li>
+    <li><a href="#data-buyer-purchases--bids-for-access-grant-to-end-device-sensor-data-listing-on-inter-chain-data-market">Data Buyer Purchases / Bids for Access Grant to End Device (Sensor) Data Listing on Inter-Chain Data Market</a>
+    <ul>
+    <li><a href="#data-buyer-payment-options">Data Buyer Payment Options</a></li>
+    </ul></li>
+    <li><a href="#data-buyer-accesses-sensor-data-frames-from-inter-chain-decentralized-app-dapp">Data Buyer Accesses Sensor Data Frames from Inter-Chain Decentralized App (DApp)</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#data-validation">Data Validation</a>
+    <ul>
+    <li><a href="#external-oracles">External Oracles</a>
+    <ul>
+    <li><a href="#purpose">Purpose</a></li>
+    <li><a href="#definition">Definition</a></li>
+    <li><a href="#types">Types</a></li>
+    <li><a href="#risk-ratings">Risk Ratings</a></li>
+    <li><a href="#example">Example</a></li>
+    </ul></li>
+    <li><a href="#swimlane-flowchart-diagrams-2">Swimlane (Flowchart) Diagrams</a>
+    <ul>
+    <li><a href="#validate--certify--store-external-data-frames-retrieved-using-oracles-notaries--data-storage-backend">Validate &amp; Certify &amp; Store External Data Frames Retrieved using Oracles, Notaries &amp; Data Storage Backend</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#data-monitoring">Data Monitoring</a>
+    <ul>
+    <li><a href="#business-concept-diagram">Business Concept Diagram</a></li>
+    </ul></li>
+    </ul></li>
+    <li><a href="#application-ecosystem">Application Ecosystem</a></li>
+    <li><a href="#technical-model">Technical Model</a>
+    <ul>
+    <li><a href="#consensus">Consensus</a></li>
+    <li><a href="#custom-substrate-runtime-modules">Custom Substrate Runtime Modules</a></li>
+    <li><a href="#node">Node</a></li>
+    <li><a href="#other-infrastructure">Other Infrastructure</a></li>
+    </ul></li>
+    <li><a href="#glossary">Glossary</a>
+    <ul>
+    <li><a href="#mining-2">Mining</a></li>
+    <li><a href="#roaming-3">Roaming</a></li>
+    </ul></li>
+    <li><a href="#abbreviations">Abbreviations</a>
+    <ul>
+    <li><a href="#mining-3">Mining</a></li>
+    <li><a href="#roaming-4">Roaming</a></li>
+    </ul></li>
+    <li><a href="#references">References</a></li>
+    <li><a href="#appendices">Appendices</a>
+    <ul>
+    <li><a href="#appendix-1-general---technical-model-of-substrate">Appendix 1: General - Technical Model of Substrate</a>
+    <ul>
+    <li><a href="#integration-of-the-data-highway-parachain-into-the-polkadot-network">Integration of the DataHighway Parachain into the Polkadot network</a></li>
+    </ul></li>
+    <li><a href="#appendix-2-roaming---lorawan-technology">Appendix 2: Roaming - LoRaWAN Technology</a></li>
+    <li><a href="#appendix-3-roaming---use-case-alice-and-bob">Appendix 3: Roaming - Use Case (Alice and Bob)</a>
+    <ul>
+    <li><a href="#assumptions">Assumptions</a></li>
+    <li><a href="#user-personas">User Personas</a></li>
+    <li><a href="#user-story">User Story</a></li>
+    </ul></li>
+    </ul></li>
+    </ul>
+</div>
+
 <div class="page-break"></div>
 
 <h2 id="introduction">Introduction</h2>
-<p>The decentralised Data Highway (DH) economic system for the future of IoT will have a monetary system of the DHX token. </p>
+<p>The decentralised DataHighway (DH) economic system for the future of IoT will have a monetary system of the DHX token. </p>
 <h4 id="dao">DAO</h4>
 <p>It will not have a central authority to regulate its monetary base and fiscal policy, instead it will be regulated by the DHX DAO, which will govern future growth strategies.</p>
 <h4 id="mining">Mining</h4>
 <p>It will allow users to be rewarded in return for participation.</p>
 <h4 id="inter-chain-data-market">Inter-Chain Data Market</h4>
-<p>The Data Highway’s (DHX) Inter-Chain Data Market allows participants to become data providers and to share IoT data from their devices to application developers in exchange for DHX tokens.</p>
+<p>The DataHighway’s (DHX) Inter-Chain Data Market allows participants to become data providers and to share IoT data from their devices to application developers in exchange for DHX tokens.</p>
 <h4 id="lpwan">LPWAN</h4>
 <p>A category of devices that run on low bandwidths (less than 125kHz, 200bps) with low power consumption (less than 2W when transmitting). Typically the technologies involved include LoRaWAN, Sigfox, Weightless, NB-IoT.</p>
 <h4 id="roaming">Roaming</h4>
 <p>Devices (LPWAN IoT End Devices) are owned by Data Providers and registered at a “home” Network Server (or Supernode that has purchased a specific Network ID) that belongs to a specific Network Operator (such as the MXC Network).</p>
-<p>Data Consumers may request to be granted access to receive packets of data that have been uplinked from a device, which may require purchasing ad-hoc access or a subscription from the Data Highway’s Inter-Chain Data Market (see separate “Inter-Chain Data Market” Whitepaper).</p>
+<p>Data Consumers may request to be granted access to receive packets of data that have been uplinked from a device, which may require purchasing ad-hoc access or a subscription from the DataHighway’s Inter-Chain Data Market (see separate “Inter-Chain Data Market” Whitepaper).</p>
 <p>Device owners may enable or disable roaming and associated payments via the LPWAN Supernode Portal.</p>
 <p>Supernode owners may also choose to restrict access to roaming devices via the LPWAN Supernode Portal.</p>
-<p>Data Highway (DH) is an implementation of an open-source and fully decentralised roaming service that allows LPWAN IoT End Devices that have enabled roaming to move out of the network coverage area of their “home” Network Server and into the network coverage area of a “visited” Network Server, where the “visited” Network Server may query the Data Highways distributed ledger (database storage) to retrieve information such as whether the device has enabled roaming, and whether an individual party to party (bilateral) roaming agreement has been established between the Network Operator of the “visited” Network Server and the Network Operator of the “home” Network Server. If the roaming join request is accepted then the packets of data that are uplinked when roaming will be forwarded such that Data Consumers gain continuous access to the data.</p>
+<p>DataHighway (DH) is an implementation of an open-source and fully decentralised roaming service that allows LPWAN IoT End Devices that have enabled roaming to move out of the network coverage area of their “home” Network Server and into the network coverage area of a “visited” Network Server, where the “visited” Network Server may query the DataHighways distributed ledger (database storage) to retrieve information such as whether the device has enabled roaming, and whether an individual party to party (bilateral) roaming agreement has been established between the Network Operator of the “visited” Network Server and the Network Operator of the “home” Network Server. If the roaming join request is accepted then the packets of data that are uplinked when roaming will be forwarded such that Data Consumers gain continuous access to the data.</p>
 <p>The Network Server’s are referred to as MXC Supernodes if they have purchased a Network ID and belong to the MXC Network. Other technologies like Sigfox and NB-IoT can also participate through Network ID based roaming.</p>
-<p>It will be compatible with the latest <a href="https://lora-alliance.org/sites/default/files/2018-04/lorawantm-backend-interfaces-v1.0.pdf">LoRaWAN Backend Interface Specification</a>. A public API will be exposed that anyone (including but not limited to LoRa Alliance DNS Operators and LoRa Alliance members) may access to allow them to setup and immutably store and retrieve information about roaming network operators (decentralized LPWAN DNS Service), networks (decentralised LPWAN Roaming Service, including purchase price for network ids), users (and their priveleges), organizations, roaming policies (accounting, billing, charging, adjustments), and profiles (routing, service).</p>
-<p>Supernodes implement the MXProtocol and provide a user-interface (UI). This UI shall be updated to allow Supernode owners and stakeholders to interact with this API, as shown in these <a href="#Proposed-Roaming-Integration-into-MXProtocol-of-LPWAN-Supernodes">proposed changes</a>.</p>
-<p>Other roaming hubs that choose to store their roaming policies and agreements on the Data Highway will be supported in their efforts. Alternatively the MXC Foundation gGmbH, Lora Alliance, Sigfox and 3GPP will facilitate the bridge between other centralized and decentralized roaming hubs and the Data Highway.</p>
-<p>Reference: Page 22 of <a href="https://www.mxc.org/hubfs/WP/MXC_technical_whitepaper.pdf">https://www.mxc.org/hubfs/WP/MXC_technical_whitepaper.pdf</a></p>
+<p>It will be compatible with the latest <a href="https://lora-alliance.org/sites/default/files/2018-04/lorawantm-backend-interfaces-v1.0.pdf" target="_blank" class="pretty-link-colored">LoRaWAN Backend Interface Specification</a>. A public API will be exposed that anyone (including but not limited to LoRa Alliance DNS Operators and LoRa Alliance members) may access to allow them to setup and immutably store and retrieve information about roaming network operators (decentralized LPWAN DNS Service), networks (decentralised LPWAN Roaming Service, including purchase price for network ids), users (and their priveleges), organizations, roaming policies (accounting, billing, charging, adjustments), and profiles (routing, service).</p>
+<p>Supernodes implement the MXProtocol and provide a user-interface (UI). This UI shall be updated to allow Supernode owners and stakeholders to interact with this API, as shown in these <a href="#Proposed-Roaming-Integration-into-MXProtocol-of-LPWAN-Supernodes" class="pretty-link-colored">proposed changes</a>.</p>
+<p>Other roaming hubs that choose to store their roaming policies and agreements on the DataHighway will be supported in their efforts. Alternatively the MXC Foundation gGmbH, Lora Alliance, Sigfox and 3GPP will facilitate the bridge between other centralized and decentralized roaming hubs and the DataHighway.</p>
+<p>Reference: Page 22 of the <a href="https://www.mxc.org/hubfs/WP/MXC_technical_whitepaper.pdf" target="_blank" class="pretty-link-colored">MXC Technical Whitepaper</a>.</p>
 <div class="page-break"></div>
 
 <h2 id="goals">Goals</h2>
-<p>Reference: Page 25 of <a href="https://www.mxc.org/hubfs/WP/MXC_technical_whitepaper.pdf">https://www.mxc.org/hubfs/WP/MXC_technical_whitepaper.pdf</a></p>
+<p>Reference: Page 25 of the <a href="https://www.mxc.org/hubfs/WP/MXC_technical_whitepaper.pdf" target="_blank" class="pretty-link-colored">MXC Technical Whitepaper</a>.</p>
 <h3 id="fair-distribution--decentralisation-model">Fair Distribution &amp; Decentralisation Model</h3>
 <ul>
 <li>No pre-mining (no DHX coins in circulation before announcement to achieve the concept of decentralisation)</li>
 <li>No ICO</li>
 </ul>
 <p><img src="https://i.imgur.com/yvZdFKO.png" alt=""></p>
-<p>Figure 0: Overview of Mining in the Data Highway</p>
+<p>Figure 0: Overview of Mining in the DataHighway</p>
 <h3 id="equal-participation-opportunity">Equal Participation Opportunity</h3>
 <p>MXC has designed a low barrier to entry to allow anyone to participate in the DH.</p>
 <h3 id="inter-chain-data-market-1">Inter-Chain Data Market</h3>
@@ -558,9 +562,9 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <h3 id="external-oracle">External Oracle</h3>
 <p>Refer to <a href="#Data-Validation">Data Validation</a> section.</p>
 <h3 id="scalability">Scalability</h3>
-<p>The Data Highway will be a Polkadot parachain that is forecast to support at least 10 TPS. Refer to quote from reference document below, which was reviewed by Dr Gavin Wood. Quote from the blog post:</p>
+<p>The DataHighway will be a Polkadot parachain that is forecast to support at least 10 TPS. Refer to quote from reference document below, which was reviewed by Dr Gavin Wood. Quote from the blog post:</p>
 <p>*”Depending on the block production algorithm and parameters, the transaction throughput of each chain can vary, and thus the overall throughput of the Polkadot network can only be estimated. The first version of Polkadot will allow up to 100 parachains, and assuming each can support at least 10 transactions per second (TPS), a lower bound on throughput would be about 1000 TPS.”*</p>
-<p>Only a limited amount of End Devices will be roaming initially, but scalability is still important for future proofing. In contrast the Data Highway’s Inter-Chain Data Market (separate section under this Whitepaper) will require a higher TPS since it includes a DEX.</p>
+<p>Only a limited amount of End Devices will be roaming initially, but scalability is still important for future proofing. In contrast the DataHighway’s Inter-Chain Data Market (separate section under this Whitepaper) will require a higher TPS since it includes a DEX.</p>
 <p><img src="https://i.imgur.com/Sc5GRdi.png" alt=""></p>
 <ul>
 <li>Reference<ul>
@@ -594,37 +598,37 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <h2 id="roadmap">Roadmap</h2>
 <h3 id="january-2020">January 2020</h3>
 <ul>
-<li>Data Highway Initial Website Published</li>
-<li>Data Highway Combined (Mining, Inter-Chain Data Market, and Roaming) Whitepaper Released (Open-Source)</li>
-<li>Data Highway Roaming Preliminary Design Implementation Published on Github (Open-Source)</li>
+<li>DataHighway Initial Website Published</li>
+<li>DataHighway Combined (Mining, Inter-Chain Data Market, and Roaming) Whitepaper Released (Open-Source)</li>
+<li>DataHighway Roaming Preliminary Design Implementation Published on Github (Open-Source)</li>
 </ul>
 <h3 id="february-2020">February 2020</h3>
 <ul>
-<li>Data Highway Testnet (Mining Only) on Substrate-based chain using PoA collators</li>
-<li>Data Highway Roaming Draft Implementation Reviewed by Parity (Substrate Builders Program)</li>
-<li>Data Highway Roaming Detailed Design Implementation Published on Github (Open-Source)</li>
-<li>Data Highway Parachain Slot Auction on Polkadot Testnet</li>
-<li>Data Highway Blockchain ported to Polkadot Parachain using Cumulus</li>
+<li>DataHighway Testnet (Mining Only) on Substrate-based chain using PoA collators</li>
+<li>DataHighway Roaming Draft Implementation Reviewed by Parity (Substrate Builders Program)</li>
+<li>DataHighway Roaming Detailed Design Implementation Published on Github (Open-Source)</li>
+<li>DataHighway Parachain Slot Auction on Polkadot Testnet</li>
+<li>DataHighway Blockchain ported to Polkadot Parachain using Cumulus</li>
 </ul>
 <h3 id="march-2020">March 2020</h3>
 <ul>
-<li>Data Highway Roaming Final Design (integration of Backend Interface 1.0 Specification)</li>
-<li>Data Highway Testnet (Mining Only) on Substrate-based chain using NPoS collators</li>
+<li>DataHighway Roaming Final Design (integration of Backend Interface 1.0 Specification)</li>
+<li>DataHighway Testnet (Mining Only) on Substrate-based chain using NPoS collators</li>
 </ul>
 <h3 id="april-2020">April 2020</h3>
 <ul>
 <li>Polkadot Mainnet Launch. See <a href="https://cdn.discordapp.com/attachments/664878094846525440/667004774062751770/unknown.png">https://cdn.discordapp.com/attachments/664878094846525440/667004774062751770/unknown.png</a></li>
-<li>Data Highway Mainnet (Mining Only) on Polkadot-compatible Parachain using Substrate’s <a href="https://wiki.polkadot.network/en/latest/polkadot/build/cumulus/">Cumulus Framework</a> or the Parachain Development Kit (PDK)</li>
-<li>Data Highway Testnet (Roaming + Mining) on Substrate-based chain using PoA collators</li>
+<li>DataHighway Mainnet (Mining Only) on Polkadot-compatible Parachain using Substrate’s <a href="https://wiki.polkadot.network/en/latest/polkadot/build/cumulus/">Cumulus Framework</a> or the Parachain Development Kit (PDK)</li>
+<li>DataHighway Testnet (Roaming + Mining) on Substrate-based chain using PoA collators</li>
 </ul>
 <h3 id="june-2020">June 2020</h3>
 <ul>
-<li>Data Highway Mainnet Upgrade (Roaming + Mining)</li>
-<li>Data Highway Testnet (Roaming + Mining + Inter-Chain Data Market) on Substrate-based chain using PoA collators</li>
+<li>DataHighway Mainnet Upgrade (Roaming + Mining)</li>
+<li>DataHighway Testnet (Roaming + Mining + Inter-Chain Data Market) on Substrate-based chain using PoA collators</li>
 </ul>
 <h3 id="july-2020">July 2020</h3>
 <ul>
-<li><p>Data Highway Mainnet Upgrade (Roaming + Mining + Inter-Chain Data Market)</p>
+<li><p>DataHighway Mainnet Upgrade (Roaming + Mining + Inter-Chain Data Market)</p>
 </li>
 <li><p>References:</p>
 <ul>
@@ -637,8 +641,50 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <h2 id="economic-configuration">Economic Configuration</h2>
 <h3 id="economic-variables">Economic Variables</h3>
 <p>The initial economic variables shown in the table below were decided upon through optioneering and may be configured:</p>
-<p><img src="https://i.imgur.com/tK4d8Lr.png" alt=""></p>
-<p>Table 1: Data Highway Economic Variables</p>
+<table>
+    <tbody><tr>
+        <td>Genesis Total Supply (Monetary Base)</td>
+        <td>100000000</td>
+    </tr>
+    <tr>
+        <td>Genesis DHX DAO Treasury Unlocked Reserves</td>
+        <td>30000000</td>
+    </tr>
+    <tr>
+        <td>Remaining Genesis Supply</td>
+        <td>70000000</td>
+    </tr>
+    <tr>
+        <td>Genesis Estimated Staking Participation Collator Pool Size</td>
+        <td>100</td>
+    </tr>
+    <tr>
+        <td>Exchange Rate (USD per DHX) Assumption</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>Block Production / Mining Time</td>
+        <td>9</td>
+    </tr>
+    <tr>
+        <td>Initial Block Reward</td>
+        <td>0.25</td>
+    </tr>
+    <tr>
+        <td>Block Reward Collator Fees (% of Annual Supply)</td>
+        <td>20%</td>
+    </tr>
+    <tr>
+        <td>Block Reward Treasury Fees (% of Annual Supply)</td>
+        <td>80%</td>
+    </tr>
+    <tr>
+        <td>Inflation Cycle Duration (Years)</td>
+        <td>4</td>
+    </tr>
+</tbody></table>
+
+<p>Table 1: DataHighway Economic Variables</p>
 <h4 id="genesis-total-symbol">Genesis Total Symbol</h4>
 <p>DHX</p>
 <h4 id="genesis-total-supply">Genesis Total Supply</h4>
@@ -678,7 +724,105 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 </ul>
 <h4 id="block-authoring--production-rewards">Block Authoring / Production Rewards</h4>
 <p>The initial token issuance halving inflation strategy cycle (halving of the block production reward) shall occur every four (4) years using the “Decreasing-Supply Algorithm”.</p>
-<p><img src="https://i.imgur.com/o6x9GdJ.png" alt=""></p>
+<table class="block-authoring">
+    <tbody><tr>
+        <th>Year</th>
+        <th>Inflation Cycle</th>
+        <th>Inflation Factor</th>
+        <th>Block Reward</th>
+        <th>Remaining Total Supply (DHX)</th>
+        <th>% of Total Supply Issued</th>
+    </tr>
+    <tr>
+        <td>2020</td>
+        <td>1</td>
+        <td>1.00</td>
+        <td>0.25</td>
+        <td>69121600</td>
+        <td>1.25</td>
+    </tr>
+    <tr>
+        <td>2021</td>
+        <td>1</td>
+        <td>1.00</td>
+        <td>0.25</td>
+        <td>68245600</td>
+        <td>2.51</td>
+    </tr>
+    <tr>
+        <td>2022</td>
+        <td>1</td>
+        <td>1.00</td>
+        <td>0.25</td>
+        <td>67369600</td>
+        <td>3.76</td>
+    </tr>
+    <tr>
+        <td>2023</td>
+        <td>1</td>
+        <td>1.00</td>
+        <td>0.25</td>
+        <td>66493600</td>
+        <td>5.01</td>
+    </tr>
+    <tr>
+        <td>2024</td>
+        <td>2</td>
+        <td>0.96</td>
+        <td>0.24</td>
+        <td>65650336</td>
+        <td>6.21</td>
+    </tr>
+    <tr>
+        <td>2025</td>
+        <td>2</td>
+        <td>0.96</td>
+        <td>0.24</td>
+        <td>64809376</td>
+        <td>7.42</td>
+    </tr>
+    <tr>
+        <td>2026</td>
+        <td>2</td>
+        <td>0.96</td>
+        <td>0.24</td>
+        <td>63968416</td>
+        <td>8.62</td>
+    </tr>
+    <tr>
+        <td>2027</td>
+        <td>2</td>
+        <td>0.96</td>
+        <td>0.24</td>
+        <td>63127456</td>
+        <td>9.82</td>
+    </tr>
+    <tr>
+        <td>2028</td>
+        <td>3</td>
+        <td>0.92</td>
+        <td>0.23</td>
+        <td>62317923</td>
+        <td>10.97</td>
+    </tr>
+    <tr>
+        <td>2029</td>
+        <td>3</td>
+        <td>0.92</td>
+        <td>0.23</td>
+        <td>61510601</td>
+        <td>12.13</td>
+    </tr>
+    <tr>
+        <td>2030</td>
+        <td>3</td>
+        <td>0.92</td>
+        <td>0.23</td>
+        <td>60703279</td>
+        <td>13.28</td>
+    </tr>
+</tbody></table>
+
 <p>Table 2: Token Issuance Halving</p>
 <p>Note: Calculations after 2030 are not shown for brevity.</p>
 <h5 id="token-issuance-initial-rate">Token Issuance Initial Rate</h5>
@@ -711,12 +855,306 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <p>The proportion of collators that should always be online to secure the blockchain is 80-90%.</p>
 <p>The forecast collator pool size staking at genesis is 100.</p>
 <p>The consensus node capacity shall be 1000 (same as ChainX).</p>
-<p><img src="https://i.imgur.com/PcMsSOE.png" alt=""></p>
+<!-- http://beautifytools.com/csv-to-html-converter.php -->
+<table>
+    <tbody><tr>
+        <th rowspan="2">Year</th>
+        <th colspan="2">Block Production / Mining Rate</th>
+        <th colspan="3">Block Reward Issuance Breakdown (in DHX)</th>
+    </tr>
+    <tr>
+        <th>Per Min.</th>
+        <th>Per Day</th>
+        <th>Block Reward Issuance Per Min. (DHX)</th>
+        <th>Block Reward Issuance Per Day (DHX)</th>
+        <th>Block Reward Issuance Per Year (DHX)</th>
+    </tr>
+    <tr>
+        <td>2020</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6667</td>
+        <td>2400</td>
+        <td>876000</td>
+    </tr>
+    <tr>
+        <td>2021</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6667</td>
+        <td>2400</td>
+        <td>876000</td>
+    </tr>
+    <tr>
+        <td>2022</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6667</td>
+        <td>2400</td>
+        <td>876000</td>
+    </tr>
+    <tr>
+        <td>2023</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6667</td>
+        <td>2400</td>
+        <td>876000</td>
+    </tr>
+    <tr>
+        <td>2024</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6000</td>
+        <td>2304</td>
+        <td>840960</td>
+    </tr>
+    <tr>
+        <td>2025</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6000</td>
+        <td>2304</td>
+        <td>840960</td>
+    </tr>
+    <tr>
+        <td>2026</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6000</td>
+        <td>2304</td>
+        <td>840960</td>
+    </tr>
+    <tr>
+        <td>2027</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.6000</td>
+        <td>2304</td>
+        <td>840960</td>
+    </tr>
+    <tr>
+        <td>2028</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.5360</td>
+        <td>2212</td>
+        <td>807322</td>
+    </tr>
+    <tr>
+        <td>2029</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.5360</td>
+        <td>2212</td>
+        <td>807322</td>
+    </tr>
+    <tr>
+        <td>2030</td>
+        <td>6.667</td>
+        <td>9600</td>
+        <td>1.5360</td>
+        <td>2212</td>
+        <td>807322</td>
+    </tr>
+</tbody></table>
+
+
 <p>Table 3: Block Production Rate &amp; Block Reward</p>
 <p>Note: Block reward treasury and collator fees have been calculated using the treasury and collator fee rates respectively.</p>
-<p><img src="https://i.imgur.com/mKO72Jp.png" alt=""></p>
+<table>
+    <tbody><tr>
+        <th rowspan="3">Year</th>
+        <th colspan="5">Collator Estimates</th>
+    </tr>
+    <tr>
+        <th>Revenue (DHX)</th>
+        <th>Max. Revenue (DHX)</th>
+        <th>Costs (DHX)</th>
+        <th>ROI (Profit Factor)</th>
+        <th>ROI (Profit Factor)</th>
+    </tr>
+    <tr>
+        <th>Per Collator Per Year (Excluding MSB &amp; MLB)</th>
+        <th>Per Collator Per Year (Including Max. MSB of 60% &amp; Max. MLB of 20%)</th>
+        <th>Per Collator Per Year (Excluding MSB &amp; MLB)</th>
+        <th>Per Collator Per Year (Excluding MSB &amp; MLB)</th>
+        <th>Per Collator Per Year (Including MSB &amp; MLB)</th>
+    </tr>
+    <tr>
+        <td>2020</td>
+        <td>1756.8</td>
+        <td>2810.9</td>
+        <td>120.0</td>
+        <td>14.6</td>
+        <td>23.4</td>
+    </tr>
+    <tr>
+        <td>2021</td>
+        <td>1752.0</td>
+        <td>2803.2</td>
+        <td>121.8</td>
+        <td>14.4</td>
+        <td>23.0</td>
+    </tr>
+    <tr>
+        <td>2022</td>
+        <td>1752.0</td>
+        <td>2803.2</td>
+        <td>123.6</td>
+        <td>14.2</td>
+        <td>22.7</td>
+    </tr>
+    <tr>
+        <td>2023</td>
+        <td>1752.0</td>
+        <td>2803.2</td>
+        <td>125.5</td>
+        <td>14.0</td>
+        <td>22.3</td>
+    </tr>
+    <tr>
+        <td>2024</td>
+        <td>1686.5</td>
+        <td>2698.4</td>
+        <td>127.4</td>
+        <td>13.2</td>
+        <td>21.2</td>
+    </tr>
+    <tr>
+        <td>2025</td>
+        <td>1681.9</td>
+        <td>2691.1</td>
+        <td>129.3</td>
+        <td>13.0</td>
+        <td>20.8</td>
+    </tr>
+    <tr>
+        <td>2026</td>
+        <td>1681.9</td>
+        <td>2691.1</td>
+        <td>131.2</td>
+        <td>12.8</td>
+        <td>20.5</td>
+    </tr>
+    <tr>
+        <td>2027</td>
+        <td>1681.9</td>
+        <td>2691.1</td>
+        <td>133.2</td>
+        <td>12.6</td>
+        <td>20.2</td>
+    </tr>
+    <tr>
+        <td>2028</td>
+        <td>1619.1</td>
+        <td>2590.5</td>
+        <td>135.2</td>
+        <td>12.0</td>
+        <td>19.2</td>
+    </tr>
+    <tr>
+        <td>2029</td>
+        <td>1614.6</td>
+        <td>2583.4</td>
+        <td>137.2</td>
+        <td>11.8</td>
+        <td>18.8</td>
+    </tr>
+    <tr>
+        <td>2030</td>
+        <td>1614.6</td>
+        <td>2583.4</td>
+        <td>139.3</td>
+        <td>11.6</td>
+        <td>18.6</td>
+    </tr>
+</tbody></table>
+
 <p>Table 4: Collator Estimated ROI</p>
-<p><img src="https://i.imgur.com/VtmfAjs.png" alt=""></p>
+<table>
+    <tbody><tr>
+        <th rowspan="3">Year</th>
+        <th colspan="3">Block Reward Distribution</th>
+    </tr>
+    <tr>
+        <th>Issuance</th>
+        <th>Collator Fees</th>
+        <th>Treasury Fees</th>
+    </tr>
+    <tr>
+        <th>Per Year (DHX)</th>
+        <th>Per Year (DHX)</th>
+        <th>Per Year (DHX)</th>
+    </tr>
+    <tr>
+        <td>2020</td>
+        <td>878400</td>
+        <td>175680</td>
+        <td>702720</td>
+    </tr>
+    <tr>
+        <td>2021</td>
+        <td>876000</td>
+        <td>175200</td>
+        <td>700800</td>
+    </tr>
+    <tr>
+        <td>2022</td>
+        <td>876000</td>
+        <td>175200</td>
+        <td>700800</td>
+    </tr>
+    <tr>
+        <td>2023</td>
+        <td>876000</td>
+        <td>175200</td>
+        <td>700800</td>
+    </tr>
+    <tr>
+        <td>2024</td>
+        <td>843264</td>
+        <td>168653</td>
+        <td>674611</td>
+    </tr>
+    <tr>
+        <td>2025</td>
+        <td>840960</td>
+        <td>168192</td>
+        <td>672768</td>
+    </tr>
+    <tr>
+        <td>2026</td>
+        <td>840960</td>
+        <td>168192</td>
+        <td>672768</td>
+    </tr>
+    <tr>
+        <td>2027</td>
+        <td>840960</td>
+        <td>168192</td>
+        <td>672768</td>
+    </tr>
+    <tr>
+        <td>2028</td>
+        <td>809533</td>
+        <td>161907</td>
+        <td>647627</td>
+    </tr>
+    <tr>
+        <td>2029</td>
+        <td>807322</td>
+        <td>161464</td>
+        <td>645857</td>
+    </tr>
+    <tr>
+        <td>2030</td>
+        <td>807322</td>
+        <td>161464</td>
+        <td>645857</td>
+    </tr>
+</tbody></table>
+
 <p>Table 5: Block Reward Distribution</p>
 <ul>
 <li>Reference:<ul>
@@ -734,6 +1172,10 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <li>Max. 20% MSB Per Proposal<ul>
 <li>Token Mining (ICBAM)<ul>
 <li>Locking of assets that are supported</li>
+<li>Sigalling<ul>
+<li>Token Miners that wish to only signal (rather than locking) attract <strong>10%</strong> of the lowest locking MSBs</li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -748,7 +1190,7 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 </ul>
 </li>
 <li>Advocacy Mining<ul>
-<li>Creating standards and patterns to satisfy community expectations, and discovering ways to maintain low transaction fees (that collators may rely on) to maintain a low barrier to entry for new Data Highway users (unless an increase in DHX price and transaction fees is supported due to rapid adoption) and prevent causing IoT fees to become prohibitively expensivel, and to reduce hardware and hosting costs to maintain ROI</li>
+<li>Creating standards and patterns to satisfy community expectations, and discovering ways to maintain low transaction fees (that collators may rely on) to maintain a low barrier to entry for new DataHighway users (unless an increase in DHX price and transaction fees is supported due to rapid adoption) and prevent causing IoT fees to become prohibitively expensivel, and to reduce hardware and hosting costs to maintain ROI</li>
 </ul>
 </li>
 <li>Governance Mining</li>
@@ -800,7 +1242,7 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 </ul>
 <p>Additionally there should be an incentive for collators to: </p>
 <ul>
-<li>Lower transaction fees to reduce the barrier to entry for new Data Highway users, which is also an overarching IoT goal.</li>
+<li>Lower transaction fees to reduce the barrier to entry for new DataHighway users, which is also an overarching IoT goal.</li>
 </ul>
 <h4 id="frequency">Frequency</h4>
 <p>Halving is the initial strategy that was chosen through optioneering to be used for the issuance of DHX through block rewards, and will be defined in the blockchain genesis configuration. The criteria was for halving to occur more frequently that every seven (7) years and less frequently than two (2) years to allow sufficient time for initial adoption.</p>
@@ -824,7 +1266,7 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 
 <h2 id="token-acquisition">Token Acquisition</h2>
 <p><img src="https://i.imgur.com/ek8nb29.png" alt=""></p>
-<p>In addition to Data Traders earning through the savings they make as a result of the democratisation of data using the decentralised Data Highway, the Inter-Chain Data Market incentives users to participate in order to potentially earn more DHX tokens, as follows:</p>
+<p>In addition to Data Traders earning through the savings they make as a result of the democratisation of data using the decentralised DataHighway, the Inter-Chain Data Market incentives users to participate in order to potentially earn more DHX tokens, as follows:</p>
 <ul>
 <li>Data Trading Transaction Fees<ul>
 <li>1% from each trade is pooled into the DHX DAO Treasury and may be automatically distributed to eligible candidates each month that must have initiated at least one trade above 0 DHX that was executed that month.</li>
@@ -877,17 +1319,18 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 </ul>
 </li>
 <li>Mining Base (Voting Power) Rewards<ul>
-<li>Data participants that earn interest in DHX from just holding DHX, MXC, IOTA, and DOT (wihout even locking it) that may be paid for using a proportion of the Token Mining boost of up to 1.2x their DHX staking profits (if they are also staking DHX as a Collator Node or Nominator), and where the MSB is always issued through DHX DAO approval. Mining Base (Voting Power) is paid for using a proportion of the MSB (if any), where MSB is always issued through DAO approval.</li>
+<li>Data participants that earn interest in DHX from just holding DHX, MXC, IOTA, and DOT (without even locking it) that may be paid for using a proportion of the Token Mining boost of up to 1.2x their DHX staking profits (if they are also staking DHX as a Collator Node or Nominator), and where the MSB is always issued through DHX DAO approval. Mining Base (Voting Power) is paid for using a proportion of the MSB (if any), where MSB is always issued through DAO approval.</li>
 </ul>
 </li>
 <li>Mining-Speed Boosts (MSB)<ul>
 <li>Token Mining by registering that any of the following tokens have been locked for a period of time: DHX, MXC, IOTA, or DOT. Paid for using DHX DAO Treasury’s Unlocked Reserves.</li>
+<li>Token Mining by Signalling, where they just hold DHX, MXC, IOTA, and DOT (without even locking it) and may be eligible to claim <strong>10%</strong> of the lowest locking MSBs rates and apply it to their DHX staking profits (if they are also staking DHX as a Collator Node or Nominator), and where the MSB is always issued through DHX DAO approval.</li>
 <li>Hardware Mining owners (i.e. End Devices, Gateway owners, Supernode owners, Collator Nodes), DHX DAO Governance participants (from the Council that audit referendums or other participants that vote on Council elections or help to organise resolution of other proposals such as categorising, proposing financial impact, disputes) where they may earn the Non-Token Mining boost of up to 1.4x their DHX staking profits through MSB.</li>
-<li>Data buyers such as Inter-Chain Data Market buyers that use Data Highway data in DApps that may be from other chains (e.g. IOTA) and increase adoption in the IoT data economy overall, thereby participate in Development Mining and/or Advocacy Mining through API referrals which contributes to the potential Non-Token Mining boost of up to 1.4x their DHX staking profits through MSB.</li>
+<li>Data buyers such as Inter-Chain Data Market buyers that use DataHighway data in DApps that may be from other chains (e.g. IOTA) and increase adoption in the IoT data economy overall, thereby participate in Development Mining and/or Advocacy Mining through API referrals which contributes to the potential Non-Token Mining boost of up to 1.4x their DHX staking profits through MSB.</li>
 </ul>
 </li>
 <li>Mining Loyalty Boost (MLB)<ul>
-<li>Loyal MXC holders that held MXC prior to the launch of the Data Highway may earn a boost of up to 1.2x their DHX staking profits through the MLB. Paid for using DHX DAO Treasury’s Unlocked Reserves.</li>
+<li>Loyal MXC holders that held MXC prior to the launch of the DataHighway may earn a boost of up to 1.2x their DHX staking profits through the MLB. Paid for using DHX DAO Treasury’s Unlocked Reserves.</li>
 </ul>
 </li>
 <li>Combo Boost<ul>
@@ -934,6 +1377,197 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <p><img src="https://i.imgur.com/EC8bEAW.png" alt=""></p>
 <p><img src="https://i.imgur.com/Xom2VPv.png" alt=""></p>
 <p><img src="https://i.imgur.com/Hn8hTb9.png" alt=""></p>
+<!-- HTML version below looks horrible -->
+
+<!-- <table style="font-size: 0.7em">
+    <tr>
+        <th>Activity Type</th>
+        <th>Name</th>
+        <th class="table-vertical-column-text">Revenue</th>
+        <th class="table-vertical-column-text">Expense</th>
+        <th>Payer</th>
+        <th>Payee</th>
+        <th>Sub-Type</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Anti-Tax Evasion Transaction Fee</td>
+        <td>X</td>
+        <td></td>
+        <td>Validator</td>
+        <td>DAO Treasury</td>
+        <td>Fee (Transaction)</td>
+        <td>Fee that must be paid (using a proportion of the block reward) by the validator that produced the block to pay for securing the blockchain to discourage validators from evading fees. Minimum fee to be paid by the Validator that shall apply per transaction is 20% of the block reward. This does not apply to Treasury validators. An additional per-byte fee may also be applied depending on the size of each transaction subject to DHX DAO approval. See [5] [6].</td>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Anti-DDoS Transaction Fee</td>
+        <td>X</td>
+        <td></td>
+        <td>End Users</td>
+        <td>Validator and DHX DAO Treasury</td>
+        <td>Fee (Transaction)</td>
+        <td>Fee that must be paid by the sender of a transaction to pay for securing the blockchain to reduce the likelihood of DDoS attacks. <br /><br />Free Transactions may apply subject to DHX DAO approval to user account proposals that demonstrated a history of staking PoP and an adequate DHX DAO Reputation Level</td>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Misbehaviour Penalty Fee</td>
+        <td>X</td>
+        <td></td>
+        <td>Validator</td>
+        <td>DHX DAO Treasury</td>
+        <td>Fee (Penalty)</td>
+        <td>Fee that must be paid by End Users as a penalty (slashing) for misbehaviour. It pays for maintaining the security of the blockchain</td>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Misbehaviour Penalty Fee</td>
+        <td>X</td>
+        <td></td>
+        <td>Validator (owned by DHX DAO Treasury)</td>
+        <td>N/A (Burn Tokens)</td>
+        <td>Negative Inflation</td>
+        <td>Fee that must be paid as a penalty (slashing) by the DHX DAO Treasury when they own a validator and are found to have misbehaved. It pays for maintaining the security of the blockchain.</td>
+    </tr>
+    <tr>
+        <td>Operating</td>
+        <td>Halving</td>
+        <td>X</td>
+        <td></td>
+        <td>Monetary Reserve</td>
+        <td>Monetary Reserve</td>
+        <td>Negative Inflation</td>
+        <td>Initiate a negative inflation from genesis by adopting halving ("Decreasing-Supply Algorithm") to decrease the block reward every "Halving Period". The DHX DAO Treasury community may propose to change inflation to a different strategy such as no inflation ("Transaction-Fee-Only Model").</td>
+    </tr>
+    <tr>
+        <td>Investing</td>
+        <td>Sale of DHX tokens</td>
+        <td>X</td>
+        <td></td>
+        <td>End Users</td>
+        <td>DEX</td>
+        <td>Issuance (of Token by DEX) or Exchange (by End User)</td>
+        <td>DEX excluded for simpler design</td>
+    </tr>
+    <tr>
+        <td>Investing</td>
+        <td>Purchase of DHX tokens</td>
+        <td></td>
+        <td>X</td>
+        <td>DEX</td>
+        <td>End Users</td>
+        <td>Investment (by DEX) or Exchange (by End User)</td>
+        <td>DEX excluded for simpler design</td>
+    </tr>
+    <tr>
+        <td>Investing</td>
+        <td>Purchase of MXC, IOTA, or DOT for the DHX DAO Treasury's Unlocked Reserves</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>End Users</td>
+        <td>Investment</td>
+        <td>Tokens may be purchased for Quantitative Easing purposes.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Payment of Block Reward</td>
+        <td></td>
+        <td>X</td>
+        <td>Monetary Reserve</td>
+        <td>Validator</td>
+        <td>Issuance (Token)</td>
+        <td>Tokens issued by the Monetary Reserve to validators that produce a valid block (with a proportion of this block reward used for the anti-tax evasion fee or the whole block reward if the validator is owned by the DHX DAO Treasury). The goal is to incentivise economic participation in the blockchain's consensus protocol and secure the blockchain. Since the reward goes to the validator that mined the block that validator has an incentive equal to the value of the fees to include as many transactions as possible in the block whereas if the reward were shared equally with the validators then there would be negligible incentive [5]. DHX DAO community governance participants may elect to modify the level of security of the blockchain protocol (i.e. modify the total supply cap).</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Refund of Anti-Tax Evasion Transaction Fees</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>Validators</td>
+        <td>Refund</td>
+        <td>Refunds may apply subject to DHX DAO approval to user account proposals that demonstrated a healthy history of staking as a validator PoP and an adequate DHX DAO Reputation Level</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Rebate of Anti-DDoS Transaction Fees</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>End User</td>
+        <td>Rebate</td>
+        <td>Future bundled Rebate Requests may be proposed for DHX DAO approval based on their DHX DAO Reputation Level.</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>DHX DAO Treasury Unlocked Reserves to fund DHX DAO approved PoP MSBs (hashrate) through proposal evidence of Inter-Chain Bridged Asset Mining (ICBAM) and Hardware, Development, Advocacy and Governance Mining</td>
+        <td></td>
+        <td>X</td>
+        <td>Monetary Reserve</td>
+        <td>DHX DAO Treasury (then End User or DHX DAO Treasury)</td>
+        <td>Fund</td>
+        <td>DHX DAO unlocked reserve funds are reserved for potential future payment. A portion of them are allocated (within a daily limit) upon each DHX DAO approval of a proposal that contains evidence (PoP) of their entitlement eligibility to receive a MSB or MLB in DHX on top of any block reward that they may have earnt (up to an upper limit of 80% comprising 20% ICBAM MSB 40% non-ICBAM and 20% MLB) when validating or nominating over a period of time. <br /><br />To become entitled in addition to their stake having to have won the block reward the identity must first have participated prior through PoP means that the DHX DAO community would deem worthy to approve of.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Proposal requesting to allocate DHX DAO unlocked reserve entitlements for PoP</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>End Users or DHX DAO Treasury</td>
+        <td>Unlock (Tokens)</td>
+        <td>Release various DHX DAO unlocked reserve entitlements subject to DHX DAO Treasury community approval.  <br /><br />DHX DAO Treasury reviews proposals that are prioritised using a DHX DAO Proposal Prioritisation Formula that shall take into consideration weightings such as the DHX DAO Reputation of the proposer. <br /><br />Rejected proposals may be appealed through the DHX DAO Appeals Court. Rejected requests that are not appealed or are rejected by the appeal will have their entitlements allocated but shall remain in the DHX DAO Treasury.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Distribution of DHX DAO Treasury Unlocked Reserves</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury</td>
+        <td>Various</td>
+        <td>Fund</td>
+        <td>DHX DAO Treasury Approvers that are eligible to approve proposals are selected using a formula that considers the proposers DHX DAO Reputation. DHX DAO Treasury Approvers are changed after each proposal. DHX DAO Treasury Approvers are responsible for rejecting or approving proposals (i.e. grant or loan request) that upon approval are allocated and distributed to the requestor. The proposal's requested funding amount determines DHX DAO Reputation Level that is required to be selected as a DHX DAO Treasury Approver (i.e. higher funding requested = higher reputation level to approve).
+        <br /><br />DHX DAO Treasury Grant Funding Proposals Reviewed Default Daily Limit applies to provide a daily upper limit on the quantity of proposals the DHX DAO may approve.
+        <br /><br />DHX DAO Treasury Grant Funding Amount Default Approval Limit applies to each requestor. Requestors may only increase it to a Custom amount through a DHX DAO decision that will take into consideration the requestor's DHX DAO Reputation (including their handing of funds that were distributed to them prior).
+        <br /><br />DHX DAO Treasury Grant Funding Staged Release Default Approval Times shall specify times when different proportions of the approved funds may be allocated for access by the requestor and with a proportion still possibly subject to the requestor providing further evidence of entitlement. The requestor's proposal may request that the funds be provided sooner at Custom times instead of the Default times through a DHX DAO decision that will take into consideration their DHX DAO Reputation (including their handing of funds that were distributed to them prior). <br /><br />DHX DAO Treasury Challenge Bounties shall be be used to fund identities in the community that identify inappropriate use of granted funds (similar to Fisherman that identify bad behaviour in the Polkadot network).
+        <br />DHX DAO Reputation Level (voting power) of an identity is measured by a DHX DAO Reputation Formula that takes into consideration weightings that include the identity's Staking history (both DH native and PoP history including prior DHX DAO proposal performance). The DHX DAO Reputation Formula and weightings may be changed through a DHX DAO decision.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>DHX DAO Dispute Resolution (Governance)</td>
+        <td></td>
+        <td>X</td>
+        <td>DHX DAO Treasury or End Users</td>
+        <td>End Users or DHX DAO Treasury</td>
+        <td>Dispute Resolution</td>
+        <td>DHX DAO Appeals Court handles dispute resolution. Disputes must be raised within a reasonable period of time after the disputed transaction or after DHX DAO Treasury rejection of a proposal.</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Loan interest collected by DAO lending from borrowers</td>
+        <td>X</td>
+        <td></td>
+        <td>End Users</td>
+        <td>DEX</td>
+        <td>Fee (Interest)</td>
+        <td>DEX excluded for simpler design</td>
+    </tr>
+    <tr>
+        <td>Financing</td>
+        <td>Loan from DAO lending to borrowing identities</td>
+        <td></td>
+        <td>X</td>
+        <td>DEX</td>
+        <td>End Users</td>
+        <td>Loan</td>
+        <td>DEX excluded for simpler design</td>
+    </tr>
+</table> -->
+
 <p>Table 6: DH Cash Flow Statement</p>
 <p>Reference: <a href="https://docs.google.com/spreadsheets/d/1pVp7wXq_CxZEmt-5jHVSd1oO1txPCq_U1_drMIceTiw/edit#gid=0">https://docs.google.com/spreadsheets/d/1pVp7wXq_CxZEmt-5jHVSd1oO1txPCq_U1_drMIceTiw/edit#gid=0</a></p>
 <div class="page-break"></div>
@@ -1013,12 +1647,13 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <ul>
 <li>PoP ICBAM MSB Periods Available<ul>
 <li>MXC ICBAM MSB is calculated using a linear regression formula <code>1.025*0.00015*days_mxc_held</code> of the form <code>y=a+bx</code>, where <code>y</code> is the dependent variable on the y axis, <code>x</code> is the independent variable plotted on the x axis, <code>b</code> is the slope of the line, and <code>a</code> is the y-intercept</li>
-<li>IOTA and DOT ICBAM MSB is calculated using a linear regression formula <code>1.0125*0.000075*days_mxc_held</code> of the form <code>y=a+bx</code></li>
+<li>IOTA and DOT ICBAM MSB Locking is calculated using a linear regression formula <code>1.0125*0.000075*days_mxc_held</code> of the form <code>y=a+bx</code></li>
 <li>3, 6, 9, 12, 24, 36 months (maximum)<ul>
 <li>MXC corresponding MSBs are approx. 1.025, 1.05, 1.075, 1.10, 1.15, 1.2</li>
-<li>IOTA, DOT corresponding MSBs are approx. 1.0125, 1.025, 1.0375, 1.05, 1.075, 1.1</li>
+<li>IOTA, DOT corresponding lower MSBs are approx. 1.0125, 1.025, 1.0375, 1.05, 1.075, 1.1</li>
 </ul>
 </li>
+<li>Signalling when Token Mining receives 10% of the lower MSBs (those that apply to IOTA and DOT)</li>
 </ul>
 </li>
 </ul>
@@ -1028,7 +1663,7 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <li>MXC, IOTA, or DOT</li>
 </ul>
 </li>
-<li>PoP ICBAM MSB Range <ul>
+<li>PoP ICBAM MSB Range for Locking. Signalling receives 10% of lowest MSB. <ul>
 <li>1.0-1.2</li>
 </ul>
 </li>
@@ -1088,7 +1723,7 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <p>An identity may earn an MSB factor through PoP.</p>
 <p>MXC receives a PoP MSB approx. twice as high as using IOTA or DOT.</p>
 <ul>
-<li>Example - MSB: If a user stakes as a collator or a nominator and receives a proportion of the block reward of <code>4</code> DHX for producing a block at the same time as they are participating in PoP ICBAM with IOTA for 36 months that gives a <code>1.1</code> PoP ICBAM MSB, and they also received a <code>1.4</code> PoP Non-ICBAM MSB, then they will instead receive a block reward of <code>4 * (1.1 + 1.4) = 6 DHX</code>.</li>
+<li>Example - MSB: If a user stakes as a collator or a nominator and receives a proportion of the block reward of <code>4</code> DHX for producing a block at the same time as they are participating in PoP ICBAM by Locking with IOTA for 36 months that gives a <code>1.1</code> PoP ICBAM MSB, and they also received a <code>1.4</code> PoP Non-ICBAM MSB, then they will instead receive a block reward of <code>4 * (1.1 + 1.4) = 6 DHX</code>. Note: If they only Signalled instead of Locking then they would receive 10% (i.e. <code>1.01</code> PoP ICBAM MSB) instead.</li>
 </ul>
 <h3 id="mining-loyalty-bonus-mlb">Mining Loyalty Bonus (MLB)</h3>
 <p>MLB is introduced to reward long-term holders of MXC, IOTA, or DOT for their loyalty. </p>
@@ -1398,7 +2033,9 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <ul>
 <li><p>Calculate Voting Power</p>
 </li>
-<li><p>Calculate ICBAM MSB</p>
+<li><p>Calculate ICBAM MSB from Locking</p>
+</li>
+<li><p>Calculate ICBAM MSB from Signalling </p>
 </li>
 <li><p>Calculate Hardware MSB (using Table 1.5)</p>
 <ul>
@@ -1426,7 +2063,7 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <h3 id="development-mining-runtimes--dapps-as-collateral">Development Mining (Runtimes &amp; DApps as Collateral)</h3>
 <h4 id="background--benefits-2">Background &amp; Benefits</h4>
 <ul>
-<li>Incubate Runtime &amp; DApp development on Data Highway through DHX funding (e.g. DApps, Bounties)</li>
+<li>Incubate Runtime &amp; DApp development on DataHighway through DHX funding (e.g. DApps, Bounties)</li>
 </ul>
 <h4 id="goals-3">Goals</h4>
 <ul>
@@ -1502,7 +2139,7 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <h3 id="advocacy-mining-marketing-as-collateral">Advocacy Mining (Marketing as Collateral)</h3>
 <h4 id="background--benefits-3">Background &amp; Benefits</h4>
 <ul>
-<li>Incubate Runtime &amp; DApp development on Data Highway through DHX funding (e.g. Referrals, Publications, Presentations, Ambassadors, Sponsors)</li>
+<li>Incubate Runtime &amp; DApp development on DataHighway through DHX funding (e.g. Referrals, Publications, Presentations, Ambassadors, Sponsors)</li>
 </ul>
 <h4 id="goals-4">Goals</h4>
 <ul>
@@ -1575,7 +2212,7 @@ Refer to steps outlined in <a href="https://github.com/DataHighway-DHX/documenta
 <h3 id="governance-mining-governance-as-collateral">Governance Mining (Governance as Collateral)</h3>
 <h4 id="background--benefits-4">Background &amp; Benefits</h4>
 <ul>
-<li>Incubate Runtime &amp; DApp development on Data Highway through DHX funding (e.g. Governance, Voting)</li>
+<li>Incubate Runtime &amp; DApp development on DataHighway through DHX funding (e.g. Governance, Voting)</li>
 </ul>
 <h4 id="goals-5">Goals</h4>
 <p>TODO</p>
@@ -1610,16 +2247,16 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <li>Min. bid required to join for roaming End Devices</li>
 </ul>
 <p>End Device owner user of an organization exchanges a money type (e.g. another token or fiat) for sufficient MXC.</p>
-<p>Supernode information is stored on the Data Highway (i.e. IP address that may change later, min. bid required)</p>
-<p>End Device owner turns on roaming in the UI of the LPWAN Server and their information (i.e. roaming enabled) is stored on the Data Highway.</p>
-<p>End Device moves from its Home NS to another NS, and the NS queries the Data Highway to find out the End Devices JS IP address and Home NS. SMB occurs (agreement automated based on quantity of packets sent, min. bid required by SN/GW, max. bid by End Device), join request is forwarded to JS via Home NS, then accept/reject whether the End Device is allowed to roam with the other NS (packets are forwarded without having to frequently agree). See “Activation Passive Roaming” <a href="https://drive.google.com/file/d/17vyq7nVhb_fQ0a4opLI4TEKDK5laUqqq/view?usp=sharing">https://drive.google.com/file/d/17vyq7nVhb_fQ0a4opLI4TEKDK5laUqqq/view?usp=sharing</a></p>
+<p>Supernode information is stored on the DataHighway (i.e. IP address that may change later, min. bid required)</p>
+<p>End Device owner turns on roaming in the UI of the LPWAN Server and their information (i.e. roaming enabled) is stored on the DataHighway.</p>
+<p>End Device moves from its Home NS to another NS, and the NS queries the DataHighway to find out the End Devices JS IP address and Home NS. SMB occurs (agreement automated based on quantity of packets sent, min. bid required by SN/GW, max. bid by End Device), join request is forwarded to JS via Home NS, then accept/reject whether the End Device is allowed to roam with the other NS (packets are forwarded without having to frequently agree). See “Activation Passive Roaming” <a href="https://drive.google.com/file/d/17vyq7nVhb_fQ0a4opLI4TEKDK5laUqqq/view?usp=sharing">https://drive.google.com/file/d/17vyq7nVhb_fQ0a4opLI4TEKDK5laUqqq/view?usp=sharing</a></p>
 <p>No agreement is established or payment required if join is rejected, since the packets are dropped.</p>
 <p>End Device owners are sent an email notification recommending that they topup with a sufficient balance to pay for roaming network access when their balance drops too low, otherwise it will be disabled.</p>
 <p>End Device roaming packets and associated Network Servers that forward them are stored in a counter that is reset to 0 each week, sufficiently after associated roaming fees and payments were made so it may be reverted if the counter value is found to be incorrect. Otherwise the list of changing IP addresses may get too long. The finalized transaction is used to prove whether the counter value is legitimate.</p>
-<p>Monthly payments are calculated on the Data Highway (for subscription payment plan) and DHX billing, charging, and payments are done automatically.</p>
+<p>Monthly payments are calculated on the DataHighway (for subscription payment plan) and DHX billing, charging, and payments are done automatically.</p>
 <h4 id="transaction-fees-subscription-based-or-ad-hoc-usage">Transaction Fees (Subscription-based or Ad-Hoc Usage)</h4>
 <p>Each of the initial 21 Supernodes (SNs) need to top-up MXC to get a sufficient amount in their SN to be able achieve a threshold holding that will allow them to generate a unique NetID (Network ID) that’s associated with their SN and will be recorded on-chain.</p>
-<p>End Devices that is activated at their “home” Supernode, once activated, will have had a DevAddr stored on the End Device, which contains a NwkAddr (which is derived from the “home” Supernode’s unique Network ID). The LPWAN Server (Supernode powered by MXProtocol) will then make one or more POST request from the LPWAN App Server codebase to the Data Highway to store roaming related information about that End Device on the distributed ledger database (under the RoamingBaseProfile class’s <code>devAddr</code> and <code>homeNet</code> properties of the EndDevice class), as shown in the <a href="#Class-Diagrams">Roaming Class Diagram</a>. </p>
+<p>End Devices that is activated at their “home” Supernode, once activated, will have had a DevAddr stored on the End Device, which contains a NwkAddr (which is derived from the “home” Supernode’s unique Network ID). The LPWAN Server (Supernode powered by MXProtocol) will then make one or more POST request from the LPWAN App Server codebase to the DataHighway to store roaming related information about that End Device on the distributed ledger database (under the RoamingBaseProfile class’s <code>devAddr</code> and <code>homeNet</code> properties of the EndDevice class), as shown in the <a href="#Class-Diagrams">Roaming Class Diagram</a>. </p>
 <p>End Device owners may subscribed to roaming or pay ad-hoc roaming fees in DHX to gain sufficient balance to roam. This will be recorded under the RoamingBaseProfile class’s <code>expiry</code> date property of the EndDevice class).</p>
 <p>Supernodes earn DHX from these Roaming Transaction Fees and are responsible distributing a cut in accordance with <strong>Roaming Operations Fees</strong>.</p>
 <p>End Devices may only be allowed to roam at a “visited” Network Server (or Supernode) when:</p>
@@ -1627,12 +2264,12 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <li>End Device owner subscribes to roaming or pays ad-hoc roaming fees in DHX and has sufficient balance.</li>
 <li>Roaming policies and agreements have been executed between the Network Operator of the End Device’s “home” network server (or Supernode) and the Network Operator of the “visited” network server (or Supernode).</li>
 <li>End Device behaviour satisfies the relevant roaming policies and agreements</li>
-<li>The “visited” network server (if not a Supernode) supports the MXProtocol (i.e. supports querying decentralized DNS of the Data Highway to find the “home” network server or Supernode, and retrieving the roaming policies and agreements, if any) or similar equivalent.</li>
+<li>The “visited” network server (if not a Supernode) supports the MXProtocol (i.e. supports querying decentralized DNS of the DataHighway to find the “home” network server or Supernode, and retrieving the roaming policies and agreements, if any) or similar equivalent.</li>
 </ul>
-<p>In the situation where the End Device tries to roam by attempting to join a “visited” Supernode, that “visited” Supernode will check for the DevAddr in the uplinked packets, then make a query from the LPWAN App Server codebase (written in GoLang and powered by MXProtocol) to the Data Highway to lookup whether roaming fees have been paid by that End Device (stored under the RoamingBaseProfile class’s <code>expiry</code> date property of the EndDevice class), and if so it will return “home” Supernode’s IP address (if the Network ID is recognizable), otherwise it will just drop the uplinked packets.</p>
-<p>If the End Device owner changed it’s roaming configuration (in the UI, see <a href="#Intuitive-UX">Intuitive-UX</a>) but the transaction was still pending, then the Supernode could still find out if that’s the case by querying the <code>pending_extrinsics</code> of the Data Highway parachain.</p>
+<p>In the situation where the End Device tries to roam by attempting to join a “visited” Supernode, that “visited” Supernode will check for the DevAddr in the uplinked packets, then make a query from the LPWAN App Server codebase (written in GoLang and powered by MXProtocol) to the DataHighway to lookup whether roaming fees have been paid by that End Device (stored under the RoamingBaseProfile class’s <code>expiry</code> date property of the EndDevice class), and if so it will return “home” Supernode’s IP address (if the Network ID is recognizable), otherwise it will just drop the uplinked packets.</p>
+<p>If the End Device owner changed it’s roaming configuration (in the UI, see <a href="#Intuitive-UX">Intuitive-UX</a>) but the transaction was still pending, then the Supernode could still find out if that’s the case by querying the <code>pending_extrinsics</code> of the DataHighway parachain.</p>
 <p>Note that this is separate from staking where a user who is an MXC holder chooses one of the 21 Supernodes and participates in staking by depositing their MXC in it to earn DHX depending on how much data that Supernode processes.</p>
-<p>Network Operators may benefit from interoperability through decentralised DNS and earn DHX from roaming fees. Network Operators outside of the MXC network may always access the MXC network’s decentralised DNS that is provided by the Data Highway, and they may choose to either establish publicly accessible decentralized roaming policies directly on the Data Highway or to update existing roaming policies (e.g. on ThingPark Exchange) and create new agreements (e.g. with MXC Foundation on ThingPark Exchange)</p>
+<p>Network Operators may benefit from interoperability through decentralised DNS and earn DHX from roaming fees. Network Operators outside of the MXC network may always access the MXC network’s decentralised DNS that is provided by the DataHighway, and they may choose to either establish publicly accessible decentralized roaming policies directly on the DataHighway or to update existing roaming policies (e.g. on ThingPark Exchange) and create new agreements (e.g. with MXC Foundation on ThingPark Exchange)</p>
 <h4 id="operations-fees">Operations Fees</h4>
 <p>Supernodes earn DHX from these Roaming Transaction Fees and are responsible for <strong>distributing</strong> a cut toward different <strong>Roaming Operations Fees</strong> depending on whether the owner of the End Device pays a Subscription or just pays for Ad-Hoc usage of roaming. </p>
 <h5 id="subscription">Subscription</h5>
@@ -1681,7 +2318,7 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <li>TransactionByteFee - per-byte portion of a transaction fee</li>
 </ul>
 <h4 id="changes-to-roaming-fees">Changes to Roaming Fees</h4>
-<p>The fees may be changed by upgrading the Data Highway parachain by using the Sudo SRML. The stakeholders of the parachain may wish to vote on how the fees should change, which would require use of the Democracy SRML (governance module).</p>
+<p>The fees may be changed by upgrading the DataHighway parachain by using the Sudo SRML. The stakeholders of the parachain may wish to vote on how the fees should change, which would require use of the Democracy SRML (governance module).</p>
 <ul>
 <li>References:<ul>
 <li>Balances SRML - <a href="https://github.com/paritytech/substrate/blob/master/srml/balances/src/lib.rs">https://github.com/paritytech/substrate/blob/master/srml/balances/src/lib.rs</a></li>
@@ -1704,23 +2341,23 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 </ol>
 <ul>
 <li>MXC tokens may already be obtained from various DEXs</li>
-<li>DHX tokens may be obtained initially through Data Highway Mining &amp; Governance (see Mining Whitepaper)</li>
+<li>DHX tokens may be obtained initially through DataHighway Mining &amp; Governance (see Mining Whitepaper)</li>
 <li>DHX tokens may be also be obtained in future for MXC tokens through a DEX (see Inter-Chain Data Market Whitepaper)</li>
 <li>See the “DHX Token Acquisition” section of the Inter-Chain Data Market Whitepaper for further details.</li>
 </ul>
 <h3 id="data-storage">Data Storage</h3>
 <h4 id="storage-requirements">Storage Requirements</h4>
-<p>End Device information that should be stored on the Data Highway includes:</p>
+<p>End Device information that should be stored on the DataHighway includes:</p>
 <ul>
 <li>Roaming Configuration<ul>
 <li>Mapping of whether an End Device has enabled roaming and its expiry date</li>
 <li>“home” Network Server’s DNS resolution information</li>
-<li>Owner Account ID on the Data Highway and their User ID and Oorganization ID on the LPWAN Server</li>
+<li>Owner Account ID on the DataHighway and their User ID and Oorganization ID on the LPWAN Server</li>
 </ul>
 </li>
 <li>Owner Information<ul>
 <li>M2M Wallet User ID (which may be associated with multiple Organisation IDs, and the End Device may be part of one of its Organisation IDs).</li>
-<li>Organization ID should have an MXC “network” balance so the owner of the End Device may exchange them for the Data Highway’s “data” tokens (DHX) to pay for roaming</li>
+<li>Organization ID should have an MXC “network” balance so the owner of the End Device may exchange them for the DataHighway’s “data” tokens (DHX) to pay for roaming</li>
 </ul>
 </li>
 <li>Smart Machine Bidding (SMB) and Forwarding Parameters:<ul>
@@ -1729,17 +2366,17 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 </li>
 </ul>
 <h4 id="storage-periodic-maintenance-and-migration">Storage Periodic Maintenance and Migration</h4>
-<p>Data Highway nodes should be able to be run on servers without storing unnecessary data.</p>
+<p>DataHighway nodes should be able to be run on servers without storing unnecessary data.</p>
 <h5 id="data-pruning">Data Pruning</h5>
-<p>On Polkadot, all data related to an account is pruned when the account’s balance drops below an existential deposit value (avoids dust accounts). The Data Highway will include this feature.</p>
-<p>Data Highway nodes may be run with <code>pruning=1000000</code> to discard historical data prior to a certain block 1000000 (not with <code>pruning=archive</code>). This will be useful on the Data Highway, since the Data Highway will be a public chain with an initial database size of 0 GB. After 1 year its database size could be over 5Gb, and over 10Gb after 2 years. The payment related roaming data stored in the database is for audit purposes, where an audit of payments and disputes of payment transactions may occur for up to 1 year after the payment occurred, such that no payments in the first year can be reverted by lodging proposal through governance, and as such those historical records are no longer required.</p>
+<p>On Polkadot, all data related to an account is pruned when the account’s balance drops below an existential deposit value (avoids dust accounts). The DataHighway will include this feature.</p>
+<p>DataHighway nodes may be run with <code>pruning=1000000</code> to discard historical data prior to a certain block 1000000 (not with <code>pruning=archive</code>). This will be useful on the DataHighway, since the DataHighway will be a public chain with an initial database size of 0 GB. After 1 year its database size could be over 5Gb, and over 10Gb after 2 years. The payment related roaming data stored in the database is for audit purposes, where an audit of payments and disputes of payment transactions may occur for up to 1 year after the payment occurred, such that no payments in the first year can be reverted by lodging proposal through governance, and as such those historical records are no longer required.</p>
 <h5 id="data-retention-and-periodic-migration">Data Retention and Periodic Migration</h5>
 <p>Other data that was stored in historic blocks (e.g. whether there is sufficient balance to be a Supernode, and the “home” NS associated with an End Device, etc) may still be required and should be migrated to a newer block that is not part of the historic blocks that are to be pruned.</p>
 <h3 id="architecture">Architecture</h3>
 <h4 id="class-diagrams">Class Diagrams</h4>
 <p><img src="https://i.imgur.com/QV5ShUR.jpg" alt=""></p>
 <h5 id="aggregations-of-smb-and-forwarding">Aggregations (of SMB and Forwarding)</h5>
-<p>Aggregations associated with Smart Machine Bidding (SMB) and packet forwarding from “visited” Network Servers back to the roaming End Device’s “home” Network Server may also be stored on the Data Highway, if necessary.</p>
+<p>Aggregations associated with Smart Machine Bidding (SMB) and packet forwarding from “visited” Network Servers back to the roaming End Device’s “home” Network Server may also be stored on the DataHighway, if necessary.</p>
 <p><img src="https://i.imgur.com/bgTLbxO.png" alt=""></p>
 <ul>
 <li>Source: roaming_class_diagram</li>
@@ -1751,7 +2388,7 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <h5 id="lpwan-supernode-network-setup-shared-identity--staking">LPWAN Supernode Network Setup, Shared Identity &amp; Staking</h5>
 <ol>
 <li>Register Organisations ID at MXC’s M2M Portal.</li>
-<li>Generate Data Highway (DH) Parachain Account ID.</li>
+<li>Generate DataHighway (DH) Parachain Account ID.</li>
 <li>Store mapping of Organisation ID, Supernode ID and Shared Identity (Parachain Account ID) on parachain.</li>
 <li>Store Staking requirements for Supernodes on the parachain.</li>
 <li>Obtain Network ID for Supernode by locking the minimum MXC tokens to Stake on a Supernode ready for Contour Payments. Pay fee for Network ID.</li>
@@ -1809,9 +2446,9 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <h4 id="roaming-at-a-supernode-that-is-registered-on-the-mxc-network-using-an-end-device-from-a-different-network-operator-that-is-registered-on-thingpark-exchange-tex">Roaming at a Supernode that is registered on the MXC Network using an End Device from a different Network Operator that is registered on ThingPark Exchange (TEX)</h4>
 <ul>
 <li>MXProtocol Policy Integrated into ThingPark Partners UI</li>
-<li>Roaming Policy stored on Data Highway</li>
-<li>IT Integration Setup Whitelisting stored on Data Highway</li>
-<li>Store Profile Of End Device on Data Highway so no request required to to Home NS</li>
+<li>Roaming Policy stored on DataHighway</li>
+<li>IT Integration Setup Whitelisting stored on DataHighway</li>
+<li>Store Profile Of End Device on DataHighway so no request required to to Home NS</li>
 <li>Periodic Billing &amp; Payments via MXC Service</li>
 <li>Roaming API</li>
 </ul>
@@ -1829,7 +2466,7 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <ul>
 <li>Create MXProtocol Policies for roaming on ThingPark Exchange (between MXC Network Operator and others on ThingPark Exchange e.g. Swisscom, Orange)</li>
 <li>Optionally the Swisscom Network Server (NS) may also support MXProtocol.</li>
-<li>Use Data Highway Parachain Roaming API to check Roaming Agreement Policy for network associated with End Device (MXC)</li>
+<li>Use DataHighway Parachain Roaming API to check Roaming Agreement Policy for network associated with End Device (MXC)</li>
 <li>Use Roaming API to check Roaming Whitelisting</li>
 <li>Use Roaming API to accept the Roaming Policy and start Roaming Accounting</li>
 <li>Use MXProtocol Policy that is integrated into ThingPark Partners UI to audit periodic (i.e. monthly) payments from MXC, which queries the Roaming API for Billing &amp; Payments</li>
@@ -1936,8 +2573,8 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <h5 id="types">Types</h5>
 <p>External Oracle types:</p>
 <ul>
-<li>Software Oracles - feed information that originates online into the Data Highway parachain runtime</li>
-<li>Hardware Oracles - feeds IoT sensor data from the physical world into the Data Highway parachain runtime</li>
+<li>Software Oracles - feed information that originates online into the DataHighway parachain runtime</li>
+<li>Hardware Oracles - feeds IoT sensor data from the physical world into the DataHighway parachain runtime</li>
 <li>Inbound Oracles - feeds data from the external world</li>
 <li>Outbound Oracles - listen and respond to on-chain data events such as payment events prior to triggering IoT devices</li>
 <li>Consensus-based Oracles - DAO data (human consensus) or prediction markets (e.g. Augur, Gnosis) that implement a rating system for Oracles and for security they require a combination of the Oracles to all agree in order to gain confidence as to the outcome of an event.</li>
@@ -1945,7 +2582,7 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <h5 id="risk-ratings">Risk Ratings</h5>
 <p>External Oracle Risk Ratings are necessary to mitigate risks such as “man-in-the-middle attacks” between parachain runtimes or smart contracts and the Oracles themselves by using different trusted computing techniques.</p>
 <h5 id="example">Example</h5>
-<p>Data Buyer purchases from the Inter-Chain Data Market access to IoT data from a specific End Device that is at a specific location and is owned by a Data Seller (Provider). The Inter-Chain Data Market module of the Data Highway parachain or smart contract specifies that the promised data needs to be available via the API and shall not be compromised.</p>
+<p>Data Buyer purchases from the Inter-Chain Data Market access to IoT data from a specific End Device that is at a specific location and is owned by a Data Seller (Provider). The Inter-Chain Data Market module of the DataHighway parachain or smart contract specifies that the promised data needs to be available via the API and shall not be compromised.</p>
 <p>External Oracles validate the IoT data that is stored in a Data Storage Backend (e.g. Alibaba Cloud or similar equivalent) and notaries certify a hash of the data that is commited on-chain. IoT data that must be validated includes but is not limited to that comprising the agreement between the Data Provider and Data Buyer, such as:</p>
 <ul>
 <li>Price feed data for financial aspects that show USD-equivalent value of token assets</li>
@@ -2097,7 +2734,7 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <pre><code class="hljs rust">  <span class="hljs-comment">// GENERAL MINING</span>
 
   <span class="hljs-comment">// Mining Speed (Base + Boosts).</span>
-  <span class="hljs-comment">// Applies to DHX Profits from Staking on Data Highway</span>
+  <span class="hljs-comment">// Applies to DHX Profits from Staking on DataHighway</span>
   <span class="hljs-keyword">pub</span> MiningSpeedOf get (parachainAccount): map(T: ParachainAccountId) =&gt; (T: Speed);
 
   <span class="hljs-keyword">pub</span> <span class="hljs-class"><span class="hljs-keyword">enum</span> <span class="hljs-title">MiningSpeedBaseForTokenType</span></span> {
@@ -2352,7 +2989,7 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 </ul>
 </li>
 <li>Notifications<ul>
-<li>Data Highway Discord Bot (similar to Polkabot)</li>
+<li>DataHighway Discord Bot (similar to Polkabot)</li>
 </ul>
 </li>
 <li>UI<ul>
@@ -2420,9 +3057,9 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <li>BAT - Block Authoring / Production Time (“Block Time”)</li>
 <li>BPT - Block Propagation Time (Network Latency)</li>
 <li>DAO - Decentralized Autonomous Organization</li>
-<li>DH - Data Highway</li>
-<li>DHX - Data Highway Asset Token</li>
-<li>DHX DAO - Data Highway DAO</li>
+<li>DH - DataHighway</li>
+<li>DHX - DataHighway Asset Token</li>
+<li>DHX DAO - DataHighway DAO</li>
 <li>ICBA - Inter-Chain Bridged Asset</li>
 <li>ICBAM - Inter-Chain Bridged Asset Mining</li>
 <li>MDT - PoP Mining Diversity Threshold</li>
@@ -2439,7 +3076,7 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 <h3 id="roaming-4">Roaming</h3>
 <ul>
 <li>AS - Application Server</li>
-<li>DH - Data Highway</li>
+<li>DH - DataHighway</li>
 <li>ED - End Device</li>
 <li>FNS - Forwarding Network Server</li>
 <li>IoT - Internet of Things</li>
@@ -2472,10 +3109,10 @@ Supernode owner user establishes payment conditions for roaming, such as:</li>
 
 <h2 id="appendices">Appendices</h2>
 <h3 id="appendix-1-general---technical-model-of-substrate">Appendix 1: General - Technical Model of Substrate</h3>
-<h4 id="integration-of-the-data-highway-parachain-into-the-polkadot-network">Integration of the Data Highway Parachain into the Polkadot network</h4>
+<h4 id="integration-of-the-datahighway-parachain-into-the-polkadot-network">Integration of the DataHighway Parachain into the Polkadot network</h4>
 <p><img src="https://i.imgur.com/MBAHjlg.png" alt=""></p>
 <p>(View image by right-clicking and choosing to “Open Image in New Tab” or “Save Image As”)</p>
-<p>Table A1: Polkadot Relay Chain and the Data Highway (DH) Parachain</p>
+<p>Table A1: Polkadot Relay Chain and the DataHighway (DH) Parachain</p>
 <h3 id="appendix-2-roaming---lorawan-technology">Appendix 2: Roaming - LoRaWAN Technology</h3>
 <ul>
 <li><p><strong>LoRa</strong> - physical layer technology that modulates the signals in sub-GHZ unlicensed ISM bands (i.e. 868 MHz in Europe (same as a wireless doorbell), 915 MHz in North America, and 433 MHz in Asia) using a proprietary chirp spread spectrum (CSS) modulation technique</p>

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -54,3 +54,18 @@
 .pdf-only {
   display: none;
 }
+
+table {
+  width: 100%; 
+  text-align: center;
+}
+
+tr,td { text-align: center; }
+
+.table-vertical-column-text {
+  text-align: center;
+  white-space: nowrap;
+  transform-origin: 50% 50%;
+  transform: rotate(90deg);
+  padding: 20px 0px 0px 0px;
+}


### PR DESCRIPTION
It was agreed not to proceed with this, since the generated tables in PDF look horrible, and they clip across pdf pages, whereas using images they don't.

Also on the website whitepaper, wide tables need to be horizontally scrolled, and use may not realize, and even with responsive media queries it's an annoying UX. whereas with image they can pinch and zoom, and it auto-resizes