### PR TITLE
Change the Collator Setup docs for v3.7.1

### DIFF
--- a/docs/tutorials/tutorials-nodes-collators-setup.md
+++ b/docs/tutorials/tutorials-nodes-collators-setup.md
@@ -47,10 +47,10 @@ git clone https://github.com/DataHighway-DHX/DataHighway-Parachain
 cd DataHighway-Parachain
 ```
 
-Checkout to latest release tag. At the time of updating this document, latest release was `3.6.0`
+Checkout to latest release tag. At the time of updating this document, latest release is [`3.7.1`](https://github.com/DataHighway-DHX/DataHighway-Parachain/releases/tag/v3.7.1)
 
 ```bash
-git checkout v3.6.0
+git checkout v3.7.1
 ```
 
 Build packages
@@ -84,9 +84,13 @@ wget https://github.com/DataHighway-DHX/DataHighway-Parachain/releases/download/
 wget https://github.com/DataHighway-DHX/DataHighway-Parachain/releases/download/v3.7.1/kusama-parachain-raw.json -O /opt/datahighway/kusama-parachain-raw.json
 ```
 
+### **NOTE**: If you're running a v3.6.0 node and want to upgrade to v3.7.1, please be sure to check the [GRANDPA ISSUE](https://github.com/DataHighway-DHX/DataHighway-Parachain/wiki/%5BWIP%5D-2022-11-12-GRANDPA-ISSUE).
+
 ### Set up the node as a system service.
 
 To do this, navigate into the root directory of the DataHighway-DHX/DataHighway-Parachain repo and execute the following to create the service configuration file.
+
+**NOTE**: If any command throws something like `Permission denied`, run it with *sudo*.
 
 Create a new script at `/opt/datahighway/start.sh` with the following content:
 
@@ -219,7 +223,5 @@ To start collating, you need to have 10 DHX tokens
 2. Select your _collator account_ and extrinsic type: **_parachainStaking / joinAsCandidate_**. Provide the amount of GIANT you want to stake. This should be in full denomation, For example if you want to stake 50 GIANT, enter 50000000000000000000
 
 3. Submit the transaction.
-
-
 
 Onboarding takes place at **_n+1_** session.

--- a/docs/tutorials/tutorials-nodes-collators-setup.md
+++ b/docs/tutorials/tutorials-nodes-collators-setup.md
@@ -4,7 +4,7 @@ title: Setup Collator Node
 sidebar_label: Setup Collator Node
 ---
 
-## How do you setup an Collator Node?
+## How do you setup a Collator Node?
 
 This guide covers how to set up a DataHighway Collator Node on the Tanganika Network.
 
@@ -64,6 +64,11 @@ curl https://getsubstrate.io -sSf | bash -s -- --fast && \
 
 Instead of building from source, you can download a prebuilt binary from the official DHX Parachain Github release. To get the prebuilt binary with the chainspec definitions:
 
+Create a datahighway folder in opt:
+```sh
+mkdir /opt/datahighway
+```
+
 - Datahighway binary
 ```sh
 wget https://github.com/DataHighway-DHX/DataHighway-Parachain/releases/download/v3.7.1/datahighway-collator -O /opt/datahighway/datahighway-collator-v3.7.1
@@ -76,7 +81,7 @@ wget https://github.com/DataHighway-DHX/DataHighway-Parachain/releases/download/
 
 - Datahighway chainspec file
 ```
-wget https://github.com/DataHighway-DHX/DataHighway-Parachain/releases/download/v3.7.1/datahighway-collator -O /opt/datahighway/kusama-parachain-raw.json
+wget https://github.com/DataHighway-DHX/DataHighway-Parachain/releases/download/v3.7.1/kusama-parachain-raw.json -O /opt/datahighway/kusama-parachain-raw.json
 ```
 
 ### Set up the node as a system service.
@@ -98,8 +103,8 @@ RELAY_WS_PORT="8787"
 PARA_RPC_PORT="7677"
 PARA_WS_PORT="8788"
 PARA_PORT="50555"
-PARA_DATABASE_BASE="~/.chains/datahighway-testnet/para"
-RELAY_DATABASE_BASE="~/.chains/datahighway-testnet/relay/"
+PARA_DATABASE_BASE="~/.chains/datahighway-mainnet/para"
+RELAY_DATABASE_BASE="~/.chains/datahighway-mainnet/relay/"
 PARA_BOOTNODE="/ip4/3.127.123.230/tcp/40333/p2p/12D3KooWHJ9NwkCNJ8BFD4BptJybQQSyBJm1mtr3XRpfqWR5vjaj"
 
 CMD="$COLLATOR_PATH --collator \
@@ -130,6 +135,13 @@ echo "----------------------"
 
 $CMD
 ```
+
+Notes on the parameters:
+- NAME - name of your node
+- RELAY_SPEC - chain spec file of the relay chain (download from the Github Release page)
+- PARA_SPEC - chain spec file of the parachain (download from the Github Release page)
+- PARA_DATABASE_BASE - path to the parachain database
+- RELAY_DATABASE_BASE - path to the relay database
 
 To start the collator as a service, run the following script:
 
@@ -178,9 +190,16 @@ Generate and add your Aura session keys (author ID) for your collator node to si
 
 From `/opt/datahighway` directory you can run this command:
 ```bash
-# TODO: add proper curl call to replace this command:
-./datahighway-collator-v3.7.1 key insert --base-path $fullprojectpath/.local/share/datahighway-collator --chain kusama-parachain-raw.json --scheme Sr25519 --suri $youraurasecretseed --key-type aura
+curl http://127.0.0.1:7677 -H "Content-Type:application/json;charset=utf-8" -d   '{
+    "jsonrpc":"2.0",
+    "id":1,
+    "method":"author_insertKey",
+    "params": ["aura", "$suri", "$pkey"]
+  }'
 ```
+Replace `$suri` with your node key secret word, eg: `same jelly ceiling beauty tunnel delay exile science three winner balance minute`
+
+And replace `$pkey` with the public key generated from `$suri`, eg: `0x6849bcd876d48609c6d38a6511f53873d571aaece8a73923c1488d496d3f2510`
 
 ### Set Session Keys
 


### PR DESCRIPTION
- added additional steps for the 3.7.1 setup
- removed the unnecessary steps for setting up the collator node 3.7.1
- added links to the GRANDPA issue from our Parachain wiki page
- added links to the latest release